### PR TITLE
Add minimal samples view with DuckDB backend

### DIFF
--- a/scubaduck/sample.csv
+++ b/scubaduck/sample.csv
@@ -1,0 +1,5 @@
+timestamp,event,value,user
+2024-01-01 00:00:00,login,10,alice
+2024-01-01 01:00:00,logout,20,bob
+2024-01-02 00:00:00,login,30,alice
+2024-01-02 03:00:00,login,40,charlie

--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -1,0 +1,93 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+import duckdb
+from flask import Flask, jsonify, request, send_from_directory
+
+app = Flask(__name__, static_folder="static")
+
+# Initialize DuckDB in-memory and load sample data
+con = duckdb.connect()
+con.execute(
+    "CREATE TABLE IF NOT EXISTS events AS SELECT * FROM read_csv_auto('scubaduck/sample.csv')"
+)
+
+
+@dataclass
+class Filter:
+    column: str
+    op: str
+    value: Any
+
+
+@dataclass
+class QueryParams:
+    start: str | None = None
+    end: str | None = None
+    order_by: str | None = None
+    order_dir: str = "ASC"
+    limit: int | None = None
+    columns: List[str] = field(default_factory=list)
+    filters: List[Filter] = field(default_factory=list)
+    derived_columns: Dict[str, str] = field(default_factory=dict)
+
+
+@app.route("/")
+def index() -> Any:
+    return send_from_directory(app.static_folder, "index.html")
+
+
+@app.route("/api/columns")
+def columns() -> Any:
+    rows = con.execute("PRAGMA table_info(events)").fetchall()
+    return jsonify([{"name": r[1], "type": r[2]} for r in rows])
+
+
+def build_query(params: QueryParams) -> str:
+    select_parts = [*params.columns]
+    for name, expr in params.derived_columns.items():
+        select_parts.append(f"{expr} AS {name}")
+    select_clause = ", ".join(select_parts) if select_parts else "*"
+    query = f"SELECT {select_clause} FROM events"
+    where_parts = []
+    if params.start:
+        where_parts.append(f"timestamp >= '{params.start}'")
+    if params.end:
+        where_parts.append(f"timestamp <= '{params.end}'")
+    for f in params.filters:
+        if f.op == "=" and isinstance(f.value, list):
+            vals = " OR ".join(f"{f.column} = '{v}'" for v in f.value)
+            where_parts.append(f"({vals})")
+        else:
+            val = f"'{f.value}'" if isinstance(f.value, str) else str(f.value)
+            where_parts.append(f"{f.column} {f.op} {val}")
+    if where_parts:
+        query += " WHERE " + " AND ".join(where_parts)
+    if params.order_by:
+        query += f" ORDER BY {params.order_by} {params.order_dir}"
+    if params.limit is not None:
+        query += f" LIMIT {params.limit}"
+    return query
+
+
+@app.route("/api/query", methods=["POST"])
+def query() -> Any:
+    payload = request.get_json(force=True)
+    params = QueryParams(
+        start=payload.get("start"),
+        end=payload.get("end"),
+        order_by=payload.get("order_by"),
+        order_dir=payload.get("order_dir", "ASC"),
+        limit=payload.get("limit"),
+        columns=payload.get("columns", []),
+        derived_columns=payload.get("derived_columns", {}),
+    )
+    for f in payload.get("filters", []):
+        params.filters.append(Filter(f["column"], f["op"], f.get("value")))
+    sql = build_query(params)
+    rows = con.execute(sql).fetchall()
+    return jsonify({"sql": sql, "rows": rows})
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>ScubaDuck</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css">
+  <style>
+    body { display: flex; font-family: sans-serif; margin: 0; }
+    #sidebar { width: 300px; padding: 10px; border-right: 1px solid #ccc; }
+    #view { flex: 1; padding: 10px; }
+    .field { margin-bottom: 10px; }
+  </style>
+</head>
+<body>
+  <div id="sidebar">
+    <h3>Query</h3>
+    <div class="field">
+      <label>Start <input id="start" type="text" /></label>
+    </div>
+    <div class="field">
+      <label>End <input id="end" type="text" /></label>
+    </div>
+    <div class="field">
+      <label>Order By <select id="order_by"></select>
+        <select id="order_dir">
+          <option value="ASC">ASC</option>
+          <option value="DESC">DESC</option>
+        </select>
+      </label>
+    </div>
+    <div class="field">
+      <label>Limit <input id="limit" type="number" value="100" /></label>
+    </div>
+    <div id="filters" class="field">
+      <button type="button" onclick="addFilter()">Add Filter</button>
+    </div>
+    <button onclick="dive()">Dive</button>
+  </div>
+  <div id="view">
+    <table id="results"></table>
+  </div>
+<script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
+<script>
+const columns = [];
+fetch('/api/columns').then(r => r.json()).then(cols => {
+  const orderSelect = document.getElementById('order_by');
+  cols.forEach(c => {
+    const o = document.createElement('option');
+    o.value = c.name;
+    o.textContent = c.name;
+    orderSelect.appendChild(o);
+    columns.push(c.name);
+  });
+});
+
+function addFilter() {
+  const container = document.createElement('div');
+  container.className = 'filter';
+  container.innerHTML = `
+    <select class="f-col"></select>
+    <select class="f-op">
+      <option value="=">=</option>
+      <option value="!=">!=</option>
+      <option value="<"><</option>
+      <option value=">">></option>
+    </select>
+    <input class="f-val" type="text">
+    <button type="button" onclick="this.parentElement.remove()">X</button>
+  `;
+  container.querySelector('.f-col').innerHTML = columns.map(c => `<option value="${c}">${c}</option>`).join('');
+  document.getElementById('filters').appendChild(container);
+  new Choices(container.querySelector('.f-val'), { removeItemButton: true, duplicateItemsAllowed: false });
+}
+
+function dive() {
+  const payload = {
+    start: document.getElementById('start').value,
+    end: document.getElementById('end').value,
+    order_by: document.getElementById('order_by').value,
+    order_dir: document.getElementById('order_dir').value,
+    limit: parseInt(document.getElementById('limit').value, 10),
+    columns
+  };
+  payload.filters = Array.from(document.querySelectorAll('#filters .filter')).map(f => {
+    const valInput = f.querySelector('.f-val')._choices;
+    const values = valInput.getValue(true);
+    return {column: f.querySelector('.f-col').value, op: f.querySelector('.f-op').value, value: values.length > 1 ? values : values[0]};
+  });
+  fetch('/api/query', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload)})
+    .then(r=>r.json())
+    .then(showResults);
+}
+
+function showResults(data) {
+  const table = document.getElementById('results');
+  table.innerHTML = '';
+  if (data.rows.length === 0) return;
+  const header = document.createElement('tr');
+  data.rows[0].forEach((_, i) => {
+    const th = document.createElement('th'); th.textContent = columns[i]; header.appendChild(th);
+  });
+  table.appendChild(header);
+  data.rows.forEach(row => {
+    const tr = document.createElement('tr');
+    row.forEach(v => {
+      const td = document.createElement('td'); td.textContent = v; tr.appendChild(td);
+    });
+    table.appendChild(tr);
+  });
+}
+</script>
+</body>
+</html>

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from scubaduck import server
+
+
+def test_basic_query() -> None:
+    app = server.app
+    client = app.test_client()
+    payload = {
+        "start": "2024-01-01 00:00:00",
+        "end": "2024-01-02 00:00:00",
+        "order_by": "timestamp",
+        "order_dir": "ASC",
+        "limit": 10,
+        "columns": ["timestamp", "event", "value", "user"],
+        "filters": [],
+    }
+    rv = client.post("/api/query", data=json.dumps(payload), content_type="application/json")
+    data = rv.get_json()
+    assert data
+    rows = data["rows"]
+    # We expect first three rows (until 2024-01-02 00:00:00)
+    assert len(rows) == 3
+    assert rows[0][1] == "login"
+    assert rows[1][1] == "logout"
+
+
+def test_filter_multi_token() -> None:
+    app = server.app
+    client = app.test_client()
+    payload = {
+        "start": "2024-01-01 00:00:00",
+        "end": "2024-01-02 03:00:00",
+        "order_by": "timestamp",
+        "limit": 10,
+        "columns": ["timestamp", "event", "value", "user"],
+        "filters": [
+            {"column": "user", "op": "=", "value": ["alice", "charlie"]}
+        ],
+    }
+    rv = client.post("/api/query", data=json.dumps(payload), content_type="application/json")
+    data = rv.get_json()
+    assert data
+    rows = data["rows"]
+    # Should only return rows for alice and charlie
+    assert len(rows) == 3
+    assert rows[0][3] == "alice"
+    assert rows[-1][3] == "charlie"


### PR DESCRIPTION
## Summary
- implement Flask server with DuckDB backend
- add static HTML UI with token-based filters
- provide sample CSV data
- test the query endpoint

## Testing
- `ruff check .`
- `pytest -q`