### PR TITLE
test: add Playwright UI tests

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -92,6 +92,7 @@ function dive() {
 }
 
 function showResults(data) {
+  window.lastResults = data;
   const table = document.getElementById('results');
   table.innerHTML = '';
   if (data.rows.length === 0) return;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+
+import pytest
+from werkzeug.serving import make_server
+
+from scubaduck.server import app
+
+
+@pytest.fixture()
+def server_url() -> Iterator[str]:
+    httpd = make_server("127.0.0.1", 0, app)
+    port = httpd.server_port
+    thread = threading.Thread(target=httpd.serve_forever)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        httpd.shutdown()
+        thread.join()
+

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def run_query(page: Any, url: str, *, start: str | None = None, end: str | None = None,
+              order_by: str | None = None, order_dir: str = "ASC", limit: int | None = None) -> dict[str, Any]:
+    page.goto(url)
+    page.wait_for_selector("#order_by option", state="attached")
+    if start is not None:
+        page.fill("#start", start)
+    if end is not None:
+        page.fill("#end", end)
+    if order_by is not None:
+        page.select_option("#order_by", order_by)
+    if order_dir is not None:
+        page.select_option("#order_dir", order_dir)
+    if limit is not None:
+        page.fill("#limit", str(limit))
+    page.click("text=Dive")
+    page.wait_for_function("window.lastResults !== undefined")
+    return page.evaluate("window.lastResults")
+
+
+def test_range_filters(page: Any, server_url: str) -> None:
+    data = run_query(
+        page,
+        server_url,
+        start="2024-01-02 00:00:00",
+        end="2024-01-02 04:00:00",
+        order_by="timestamp",
+        limit=100,
+    )
+    assert len(data["rows"]) == 2
+    from dateutil import parser
+
+    timestamps = [parser.parse(row[0]).replace(tzinfo=None) for row in data["rows"]]
+    assert timestamps == [
+        parser.parse("2024-01-02 00:00:00"),
+        parser.parse("2024-01-02 03:00:00"),
+    ]
+
+
+def test_order_by(page: Any, server_url: str) -> None:
+    data = run_query(
+        page,
+        server_url,
+        start="2024-01-01 00:00:00",
+        end="2024-01-03 00:00:00",
+        order_by="value",
+        order_dir="DESC",
+        limit=100,
+    )
+    values = [row[2] for row in data["rows"]]
+    assert values == sorted(values, reverse=True)
+
+
+def test_limit(page: Any, server_url: str) -> None:
+    data = run_query(
+        page,
+        server_url,
+        start="2024-01-01 00:00:00",
+        end="2024-01-03 00:00:00",
+        order_by="timestamp",
+        limit=2,
+    )
+    assert len(data["rows"]) == 2
+


### PR DESCRIPTION
## Summary
- expose raw query results on the main page for easier testing
- start a live Flask server in tests
- add Playwright tests for range filtering, ordering and limit

## Testing
- `pytest -q`