### PR TITLE
fix(web): sort ascending first

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -170,14 +170,14 @@ function handleSort(e) {
   const idx = parseInt(e.target.dataset.index, 10);
   if (sortState.index !== idx) {
     sortState.index = idx;
-    sortState.dir = 'desc';
-  } else if (sortState.dir === 'desc') {
     sortState.dir = 'asc';
   } else if (sortState.dir === 'asc') {
+    sortState.dir = 'desc';
+  } else if (sortState.dir === 'desc') {
     sortState.index = null;
     sortState.dir = null;
   } else {
-    sortState.dir = 'desc';
+    sortState.dir = 'asc';
   }
   let rows = originalRows.slice();
   if (sortState.index !== null) {

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -158,7 +158,9 @@ def test_table_sorting(page: Any, server_url: str) -> None:
     assert align == "left"
 
     header = page.locator("#results th").nth(3)
-    values = lambda: page.locator("#results td:nth-child(4)").all_inner_texts()
+
+    def values() -> list[str]:
+        return page.locator("#results td:nth-child(4)").all_inner_texts()
 
     orig_rows = values()
     assert orig_rows == ["alice", "bob", "alice", "charlie"]
@@ -166,8 +168,8 @@ def test_table_sorting(page: Any, server_url: str) -> None:
     first_sql = page.evaluate("window.lastResults.sql")
 
     header.click()
-    assert values() == sorted(orig_rows, reverse=True)
-    assert header.inner_text().endswith("▼")
+    assert values() == sorted(orig_rows)
+    assert header.inner_text().endswith("▲")
     color = page.evaluate(
         "getComputedStyle(document.querySelector('#results th:nth-child(4)')).color"
     )
@@ -175,8 +177,8 @@ def test_table_sorting(page: Any, server_url: str) -> None:
     assert page.evaluate("window.lastResults.sql") == first_sql
 
     header.click()
-    assert values() == sorted(orig_rows)
-    assert header.inner_text().endswith("▲")
+    assert values() == sorted(orig_rows, reverse=True)
+    assert header.inner_text().endswith("▼")
 
     header.click()
     assert values() == orig_rows


### PR DESCRIPTION
## Summary
- change table sorting to start ascending on first click
- update table sort tests for new behavior

## Testing
- `ruff format tests/test_web.py`
- `ruff check tests/test_web.py`
- `pyright`
- `pytest -q`
