### PR TITLE
chore(ci): split workflow into lint and test

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          activate-environment: true
+          enable-cache: true
+      - name: Install dependencies
+        run: |
+          uv sync --frozen
+          playwright install chromium
+      - name: Ruff
+        run: ruff check .
+      - name: Pyright
+        run: pyright

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test
 
 on:
   push:
@@ -18,9 +18,5 @@ jobs:
         run: |
           uv sync --frozen
           playwright install chromium
-      - name: Ruff
-        run: ruff check .
-      - name: Pyright
-        run: pyright
       - name: Pytest
         run: pytest -n auto


### PR DESCRIPTION
## Summary
- split CI workflow into separate `lint` and `test` workflows

## Testing
- `ruff check .`
- `pyright`
- `pytest -n auto -q`
