### PR TITLE
feat(ui): improve filter handling

### DIFF
--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -58,12 +58,17 @@ def build_query(params: QueryParams) -> str:
     if params.end:
         where_parts.append(f"timestamp <= '{params.end}'")
     for f in params.filters:
-        if f.op == "=" and isinstance(f.value, list):
-            vals = " OR ".join(f"{f.column} = '{v}'" for v in f.value)
-            where_parts.append(f"({vals})")
-        else:
-            val = f"'{f.value}'" if isinstance(f.value, str) else str(f.value)
-            where_parts.append(f"{f.column} {f.op} {val}")
+        if f.value is None:
+            continue
+        if isinstance(f.value, list):
+            if not f.value:
+                continue
+            if f.op == "=":
+                vals = " OR ".join(f"{f.column} = '{v}'" for v in f.value)
+                where_parts.append(f"({vals})")
+                continue
+        val = f"'{f.value}'" if isinstance(f.value, str) else str(f.value)
+        where_parts.append(f"{f.column} {f.op} {val}")
     if where_parts:
         query += " WHERE " + " AND ".join(where_parts)
     if params.order_by:

--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -19,6 +19,9 @@
     .tab-content { display: none; }
     .tab-content.active { display: block; }
     #filter_list { display: flex; flex-direction: column; }
+    #filters .filter { border: 1px solid #ccc; padding: 5px; margin-bottom: 5px; position: relative; }
+    #filters .filter button.remove { position: absolute; top: 2px; right: 2px; }
+    #filters h4 { margin: 0 0 5px 0; }
     th { text-align: left; cursor: pointer; }
     th.sorted { color: blue; }
   </style>
@@ -53,11 +56,10 @@
           <label>Limit<span class="help" title="Choose the maximum number of results to show in the chart after any aggregations have been applied. For example, a limit of 10 will show no more than 10 rows for a table, etc.">[?]</span></label>
           <input id="limit" type="number" value="100" />
         </div>
-        <div id="filters" class="field">
-          <label>Filters<span class="help" title="You can create as many filters as you want. You can either write a filter using a UI or manual SQL. In the UI, filter consists of a column name, a relation (e.g., =, !=, <, >) and then a text field. The text field is a token input. It accepts multiple tokens for = relation, in which case we match using an OR for all options.">[?]</span></label>
-          <div id="filter_list">
-            <button type="button" onclick="addFilter()">Add Filter</button>
-          </div>
+        <div id="filters">
+          <h4>Filters<span class="help" title="You can create as many filters as you want. You can either write a filter using a UI or manual SQL. In the UI, filter consists of a column name, a relation (e.g., =, !=, <, >) and then a text field. The text field is a token input. It accepts multiple tokens for = relation, in which case we match using an OR for all options.">[?]</span></h4>
+          <div id="filter_list"></div>
+          <button id="add_filter" type="button" onclick="addFilter()">Add Filter</button>
         </div>
         <div id="query_info" style="margin-top:10px;"></div>
       </div>
@@ -86,6 +88,7 @@ fetch('/api/columns').then(r => r.json()).then(cols => {
     li.textContent = c.name;
     list.appendChild(li);
   });
+  addFilter();
 });
 
 document.querySelectorAll('#tabs .tab').forEach(btn => {
@@ -109,7 +112,7 @@ function addFilter() {
       <option value=">">></option>
     </select>
     <input class="f-val" type="text">
-    <button type="button" onclick="this.parentElement.remove()">X</button>
+    <button type="button" class="remove" onclick="this.parentElement.remove()">X</button>
   `;
   container.querySelector('.f-col').innerHTML = columns.map(c => `<option value="${c}">${c}</option>`).join('');
   document.getElementById('filter_list').appendChild(container);

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -49,3 +49,30 @@ def test_filter_multi_token() -> None:
     assert len(rows) == 3
     assert rows[0][3] == "alice"
     assert rows[-1][3] == "charlie"
+
+
+def test_empty_filter_is_noop() -> None:
+    app = server.app
+    client = app.test_client()
+    base_payload = {
+        "start": "2024-01-01 00:00:00",
+        "end": "2024-01-03 00:00:00",
+        "order_by": "timestamp",
+        "limit": 100,
+        "columns": ["timestamp", "event", "value", "user"],
+    }
+    no_filter = {**base_payload, "filters": []}
+    empty_filter = {
+        **base_payload,
+        "filters": [{"column": "user", "op": "=", "value": None}],
+    }
+
+    rv1 = client.post(
+        "/api/query", data=json.dumps(no_filter), content_type="application/json"
+    )
+    rv2 = client.post(
+        "/api/query", data=json.dumps(empty_filter), content_type="application/json"
+    )
+    rows1 = rv1.get_json()["rows"]
+    rows2 = rv2.get_json()["rows"]
+    assert rows1 == rows2

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -94,6 +94,21 @@ def test_simple_filter(page: Any, server_url: str) -> None:
     assert all(row[3] == "alice" for row in data["rows"])
 
 
+def test_default_filter_and_layout(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#order_by option", state="attached")
+    count = page.evaluate("document.querySelectorAll('#filters .filter').length")
+    assert count == 1
+    last_is_button = page.evaluate(
+        "document.querySelector('#filters').lastElementChild.id === 'add_filter'"
+    )
+    assert last_is_button
+    position = page.evaluate(
+        "getComputedStyle(document.querySelector('#filters .filter button.remove')).position"
+    )
+    assert position == "absolute"
+
+
 def test_header_and_tabs(page: Any, server_url: str) -> None:
     page.goto(server_url)
     page.wait_for_selector("#order_by option", state="attached")


### PR DESCRIPTION
## Summary
- tweak filter builder to ignore empty filters
- make Filters section a standalone heading
- show an empty filter by default
- move Add Filter button to the end
- float the remove button on each filter
- test that empty filters are ignored
- check default filter layout in UI tests

## Testing
- `ruff format scubaduck/server.py tests/test_server.py tests/test_web.py`
- `ruff check scubaduck/server.py tests/test_server.py tests/test_web.py`
- `pyright`
- `pytest -n auto`