### PR TITLE
feat(web): add relative time dropdown

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -12,6 +12,8 @@
     .field { display: flex; align-items: center; margin-bottom: 10px; }
     .field label { width: 80px; text-align: right; margin-right: 5px; }
     .help { margin-left: 4px; cursor: help; }
+    .rel-btn { margin-left: 4px; }
+    .rel-select { margin-left: 4px; }
     #tabs { display: flex; align-items: center; margin-bottom: 10px; }
     #tabs .tab { margin-right: 5px; background: none; border: 1px solid #ccc; padding: 4px 8px; cursor: pointer; }
     #tabs .tab.active { background: #eee; font-weight: bold; }
@@ -36,10 +38,34 @@
         <div class="field">
           <label>Start<span class="help" title="Sets the start/end of the time range to query. Can be any kind of datetime string. For example: 'April 23, 2014' or 'yesterday'.">[?]</span></label>
           <input id="start" type="text" />
+          <button type="button" class="rel-btn" data-target="start-select">&#9660;</button>
+          <select id="start-select" class="rel-select" data-input="start" style="display:none">
+            <option value="-1 hour">-1 hour</option>
+            <option value="-3 hours">-3 hours</option>
+            <option value="-12 hours">-12 hours</option>
+            <option value="-1 day">-1 day</option>
+            <option value="-3 days">-3 days</option>
+            <option value="-1 week">-1 week</option>
+            <option value="-1 fortnight">-1 fortnight</option>
+            <option value="-30 days">-30 days</option>
+            <option value="-90 days">-90 days</option>
+          </select>
         </div>
         <div class="field">
           <label>End<span class="help" title="Sets the start/end of the time range to query. Can be any kind of datetime string. For example: 'April 23, 2014' or 'yesterday'.">[?]</span></label>
           <input id="end" type="text" />
+          <button type="button" class="rel-btn" data-target="end-select">&#9660;</button>
+          <select id="end-select" class="rel-select" data-input="end" style="display:none">
+            <option value="-1 hour">-1 hour</option>
+            <option value="-3 hours">-3 hours</option>
+            <option value="-12 hours">-12 hours</option>
+            <option value="-1 day">-1 day</option>
+            <option value="-3 days">-3 days</option>
+            <option value="-1 week">-1 week</option>
+            <option value="-1 fortnight">-1 fortnight</option>
+            <option value="-30 days">-30 days</option>
+            <option value="-90 days">-90 days</option>
+          </select>
         </div>
         <div class="field">
           <label>Order By<span class="help" title="Choose a column to sort results by.">[?]</span></label>
@@ -94,6 +120,20 @@ document.querySelectorAll('#tabs .tab').forEach(btn => {
     document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
     btn.classList.add('active');
     document.getElementById(btn.dataset.tab).classList.add('active');
+  });
+});
+
+document.querySelectorAll('.rel-btn').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const sel = document.getElementById(btn.dataset.target);
+    sel.style.display = sel.style.display === 'none' ? 'block' : 'none';
+  });
+});
+document.querySelectorAll('.rel-select').forEach(sel => {
+  sel.addEventListener('change', () => {
+    const input = document.getElementById(sel.dataset.input);
+    input.value = sel.value;
+    sel.style.display = 'none';
   });
 });
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -187,3 +187,13 @@ def test_table_sorting(page: Any, server_url: str) -> None:
         "getComputedStyle(document.querySelector('#results th:nth-child(4)')).color"
     )
     assert "0, 0, 255" not in color
+
+
+def test_relative_dropdown(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#order_by option", state="attached")
+    btn = page.query_selector('[data-target="start-select"]')
+    assert btn
+    btn.click()
+    page.select_option("#start-select", "-3 hours")
+    assert page.input_value("#start") == "-3 hours"


### PR DESCRIPTION
## Summary
- implement dropdown for relative time strings
- test dropdown on Start field

## Testing
- `ruff check .`
- `pyright`
- `pytest -q`