### PR TITLE
fix(ui): remove focus outline on filter input

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -37,6 +37,7 @@
       flex: 1;
       min-width: 60px;
       margin: 2px;
+      outline: none;
     }
     #filters .filter .chip-box { position: relative; }
     #filters .chip-input { display: flex; flex-wrap: wrap; border: 1px solid #ccc; padding: 2px; min-height: 24px; }

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -316,3 +316,16 @@ def test_chip_copy_and_paste(page: Any, server_url: str) -> None:
         "Array.from(document.querySelectorAll('#filters .filter:last-child .chip')).map(c => c.firstChild.textContent)"
     )
     assert chips[-1] == "alice,bob"
+
+
+def test_chip_input_no_outline(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#order_by option", state="attached")
+    page.click("text=Add Filter")
+    inp = page.query_selector("#filters .filter:last-child .f-val")
+    assert inp
+    inp.click()
+    outline = page.evaluate(
+        "getComputedStyle(document.querySelector('#filters .filter:last-child .f-val')).outlineStyle"
+    )
+    assert outline == "none"


### PR DESCRIPTION
## Summary
- remove focus outline on chip inputs
- verify the outline is removed via UI test

## Testing
- `ruff format`
- `ruff check`
- `pyright`
- `pytest -q`