### PR TITLE
fix(ui): hide chip dropdown on outside click

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -355,6 +355,12 @@ function initChipInput(filter) {
 
   input.addEventListener('focus', loadOptions);
   input.addEventListener('input', loadOptions);
+
+  document.addEventListener('click', evt => {
+    if (!filter.contains(evt.target)) {
+      hideDropdown();
+    }
+  });
 }
 
 function addFilter() {

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -316,3 +316,17 @@ def test_chip_copy_and_paste(page: Any, server_url: str) -> None:
         "Array.from(document.querySelectorAll('#filters .filter:last-child .chip')).map(c => c.firstChild.textContent)"
     )
     assert chips[-1] == "alice,bob"
+
+
+def test_chip_dropdown_hides_on_outside_click(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#order_by option", state="attached")
+    page.click("text=Add Filter")
+    f = page.query_selector("#filters .filter:last-child")
+    assert f
+    f.query_selector(".f-col").select_option("user")
+    inp = f.query_selector(".f-val")
+    inp.click()
+    page.wait_for_selector("#filters .filter:last-child .chip-dropdown div")
+    page.click("#header")
+    page.wait_for_selector("#filters .filter:last-child .chip-dropdown", state="hidden")


### PR DESCRIPTION
## Summary
- hide filter chip dropdown when clicking outside of filter
- add regression test for dropdown dismissal

## Testing
- `ruff format tests/test_web.py`
- `ruff check tests/test_web.py`
- `pyright`
- `pytest -q`