### PR TITLE
fix(web): handle timestamp rendering

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -602,7 +602,7 @@ function renderTable(rows) {
       const col = selectedColumns[i];
       const td = document.createElement('td');
       if (isTimeColumn(col)) {
-        const d = new Date(v.replace(' ', 'T'));
+        const d = new Date(v);
         td.textContent = d.toLocaleString('en-US', {
           weekday: 'short',
           month: 'short',

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -388,3 +388,18 @@ def test_table_enhancements(page: Any, server_url: str) -> None:
     page.mouse.up()
     end_box = header.bounding_box()
     assert end_box["width"] > start["width"]
+
+
+def test_timestamp_rendering(page: Any, server_url: str) -> None:
+    run_query(
+        page,
+        server_url,
+        start="2024-01-01 00:00:00",
+        end="2024-01-02 00:00:00",
+        order_by="timestamp",
+        limit=1,
+    )
+    cell = page.text_content("#results td")
+    assert cell != "Invalid Date"
+    valid = page.evaluate("v => !isNaN(Date.parse(v))", cell)
+    assert valid


### PR DESCRIPTION
## Summary
- handle Flask date strings in table renderer
- add regression test for timestamp rendering

## Testing
- `ruff check`
- `pyright`
- `pytest -q`