### PR TITLE
feat(ui): convert columns controls to links

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -65,6 +65,13 @@
     tr:nth-child(even) td { background: #f9f9f9; }
     tr.selected td { background: #bde4ff !important; }
     tr:hover:not(.selected) td { background: #eee; }
+    #column_actions {
+      text-align: right;
+      margin-bottom: 5px;
+    }
+    #column_actions a {
+      margin-left: 5px;
+    }
     /* Column resizer removed */
   </style>
 </head>
@@ -127,8 +134,10 @@
         <div id="query_info" style="margin-top:10px;"></div>
       </div>
       <div id="columns" class="tab-content">
-        <button id="columns_all" type="button">All</button>
-        <button id="columns_none" type="button">None</button>
+        <div id="column_actions">
+          <a id="columns_all" href="#">All</a>
+          <a id="columns_none" href="#">None</a>
+        </div>
         <div id="column_groups"></div>
       </div>
     </div>
@@ -242,11 +251,13 @@ fetch('/api/columns').then(r => r.json()).then(cols => {
     div.appendChild(ul);
     groupsEl.appendChild(div);
   });
-  document.getElementById('columns_all').addEventListener('click', () => {
+  document.getElementById('columns_all').addEventListener('click', e => {
+    e.preventDefault();
     groupsEl.querySelectorAll('input').forEach(cb => (cb.checked = true));
     updateSelectedColumns();
   });
-  document.getElementById('columns_none').addEventListener('click', () => {
+  document.getElementById('columns_none').addEventListener('click', e => {
+    e.preventDefault();
     groupsEl.querySelectorAll('input').forEach(cb => (cb.checked = false));
     updateSelectedColumns();
   });

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -252,6 +252,19 @@ def test_column_toggle_and_selection(page: Any, server_url: str) -> None:
     assert "value" not in headers
 
 
+def test_columns_links_alignment(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#order_by option", state="attached")
+    page.click("text=Columns")
+    page.wait_for_selector("#column_groups input", state="attached")
+    tag = page.evaluate("document.getElementById('columns_all').tagName")
+    assert tag == "A"
+    align = page.evaluate(
+        "getComputedStyle(document.querySelector('#column_actions')).textAlign"
+    )
+    assert align == "right"
+
+
 def test_chip_dropdown_navigation(page: Any, server_url: str) -> None:
     page.goto(server_url)
     page.wait_for_selector("#order_by option", state="attached")


### PR DESCRIPTION
## Summary
- render global column All/None controls as links
- right-align the new column links
- test that the controls are links and aligned

## Testing
- `ruff check .`
- `pyright`
- `pytest -q`
