### PR TITLE
feat(web): convert column group controls to links

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -72,6 +72,9 @@
     #column_actions a {
       margin-left: 5px;
     }
+    .col-group a {
+      margin-left: 5px;
+    }
     /* Column resizer removed */
   </style>
 </head>
@@ -216,11 +219,11 @@ fetch('/api/columns').then(r => r.json()).then(cols => {
     div.className = 'col-group';
     const header = document.createElement('div');
     header.textContent = g.name + ': ';
-    const allBtn = document.createElement('button');
-    allBtn.type = 'button';
+    const allBtn = document.createElement('a');
+    allBtn.href = '#';
     allBtn.textContent = 'All';
-    const noneBtn = document.createElement('button');
-    noneBtn.type = 'button';
+    const noneBtn = document.createElement('a');
+    noneBtn.href = '#';
     noneBtn.textContent = 'None';
     header.appendChild(allBtn);
     header.appendChild(noneBtn);
@@ -240,11 +243,13 @@ fetch('/api/columns').then(r => r.json()).then(cols => {
       li.appendChild(label);
       ul.appendChild(li);
     });
-    allBtn.addEventListener('click', () => {
+    allBtn.addEventListener('click', e => {
+      e.preventDefault();
       ul.querySelectorAll('input').forEach(cb => (cb.checked = true));
       updateSelectedColumns();
     });
-    noneBtn.addEventListener('click', () => {
+    noneBtn.addEventListener('click', e => {
+      e.preventDefault();
       ul.querySelectorAll('input').forEach(cb => (cb.checked = false));
       updateSelectedColumns();
     });

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -265,6 +265,15 @@ def test_columns_links_alignment(page: Any, server_url: str) -> None:
     assert align == "right"
 
 
+def test_column_group_links(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#order_by option", state="attached")
+    page.click("text=Columns")
+    page.wait_for_selector("#column_groups a", state="attached")
+    tag = page.evaluate("document.querySelector('#column_groups .col-group a').tagName")
+    assert tag == "A"
+
+
 def test_chip_dropdown_navigation(page: Any, server_url: str) -> None:
     page.goto(server_url)
     page.wait_for_selector("#order_by option", state="attached")


### PR DESCRIPTION
## Summary
- convert column group All/None buttons to `<a>` elements
- add style for column group links
- test that column group controls are links

## Testing
- `ruff check`
- `pyright`
- `pytest -q`