### PR TITLE
feat(server): load configurable databases

### DIFF
--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -1,23 +1,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Tuple, List
+from typing import Any, Dict, List, Tuple
 
 import time
+from pathlib import Path
+import sqlite3
 
 import duckdb
 from flask import Flask, jsonify, request, send_from_directory
-
-app = Flask(__name__, static_folder="static")
-
-# Initialize DuckDB in-memory and load sample data
-con = duckdb.connect()
-con.execute(
-    "CREATE TABLE IF NOT EXISTS events AS SELECT * FROM read_csv_auto('scubaduck/sample.csv')"
-)
-_column_types: Dict[str, str] = {
-    r[1]: r[2] for r in con.execute("PRAGMA table_info(events)").fetchall()
-}
 
 
 @dataclass
@@ -39,63 +30,26 @@ class QueryParams:
     derived_columns: dict[str, str] = field(default_factory=lambda: {})
 
 
-@app.route("/")
-def index() -> Any:
-    assert app.static_folder is not None
-    return send_from_directory(app.static_folder, "index.html")
-
-
-@app.route("/api/columns")
-def columns() -> Any:
-    rows = con.execute("PRAGMA table_info(events)").fetchall()
-    return jsonify([{"name": r[1], "type": r[2]} for r in rows])
-
-
-# Simple in-memory LRU cache for sample value queries
-_SAMPLE_CACHE: Dict[Tuple[str, str], Tuple[List[str], float]] = {}
-_CACHE_TTL = 60.0
-_CACHE_LIMIT = 200
-
-
-def _cache_get(key: Tuple[str, str]) -> List[str] | None:
-    item = _SAMPLE_CACHE.get(key)
-    if item is None:
-        return None
-    vals, ts = item
-    if time.time() - ts > _CACHE_TTL:
-        del _SAMPLE_CACHE[key]
-        return None
-    _SAMPLE_CACHE[key] = (vals, time.time())
-    return vals
-
-
-def _cache_set(key: Tuple[str, str], vals: List[str]) -> None:
-    _SAMPLE_CACHE[key] = (vals, time.time())
-    if len(_SAMPLE_CACHE) > _CACHE_LIMIT:
-        oldest = min(_SAMPLE_CACHE.items(), key=lambda kv: kv[1][1])[0]
-        del _SAMPLE_CACHE[oldest]
-
-
-@app.route("/api/samples")
-def sample_values() -> Any:
-    column = request.args.get("column")
-    substr = request.args.get("q", "")
-    if not column or column not in _column_types:
-        return jsonify([])
-    ctype = _column_types[column].upper()
-    if "CHAR" not in ctype and "STRING" not in ctype and "VARCHAR" not in ctype:
-        return jsonify([])
-    key = (column, substr)
-    cached = _cache_get(key)
-    if cached is not None:
-        return jsonify(cached)
-    rows = con.execute(
-        f"SELECT DISTINCT {column} FROM events WHERE CAST({column} AS VARCHAR) ILIKE '%' || ? || '%' LIMIT 20",
-        [substr],
-    ).fetchall()
-    values = [r[0] for r in rows]
-    _cache_set(key, values)
-    return jsonify(values)
+def _load_database(path: Path) -> duckdb.DuckDBPyConnection:
+    ext = path.suffix.lower()
+    if ext == ".csv":
+        con = duckdb.connect()
+        con.execute(
+            f"CREATE TABLE events AS SELECT * FROM read_csv_auto('{path.as_posix()}')"
+        )
+    elif ext in {".db", ".sqlite"}:
+        con = duckdb.connect()
+        sconn = sqlite3.connect(path)
+        info = sconn.execute("PRAGMA table_info(events)").fetchall()
+        col_defs = ", ".join(f"{r[1]} {r[2]}" for r in info)
+        con.execute(f"CREATE TABLE events ({col_defs})")
+        placeholders = ",".join("?" for _ in info)
+        for row in sconn.execute("SELECT * FROM events"):
+            con.execute(f"INSERT INTO events VALUES ({placeholders})", row)
+        sconn.close()
+    else:
+        con = duckdb.connect(path)
+    return con
 
 
 def build_query(params: QueryParams) -> str:
@@ -144,23 +98,88 @@ def build_query(params: QueryParams) -> str:
     return query
 
 
-@app.route("/api/query", methods=["POST"])
-def query() -> Any:
-    payload = request.get_json(force=True)
-    params = QueryParams(
-        start=payload.get("start"),
-        end=payload.get("end"),
-        order_by=payload.get("order_by"),
-        order_dir=payload.get("order_dir", "ASC"),
-        limit=payload.get("limit"),
-        columns=payload.get("columns", []),
-        derived_columns=payload.get("derived_columns", {}),
-    )
-    for f in payload.get("filters", []):
-        params.filters.append(Filter(f["column"], f["op"], f.get("value")))
-    sql = build_query(params)
-    rows = con.execute(sql).fetchall()
-    return jsonify({"sql": sql, "rows": rows})
+def create_app(db_file: str | Path | None = None) -> Flask:
+    app = Flask(__name__, static_folder="static")
+    db_path = Path(db_file or Path(__file__).with_name("sample.csv")).resolve()
+    con = _load_database(db_path)
+    column_types: Dict[str, str] = {
+        r[1]: r[2] for r in con.execute("PRAGMA table_info(events)").fetchall()
+    }
+
+    sample_cache: Dict[Tuple[str, str], Tuple[List[str], float]] = {}
+    CACHE_TTL = 60.0
+    CACHE_LIMIT = 200
+
+    @app.route("/")
+    def index() -> Any:  # pyright: ignore[reportUnusedFunction]
+        assert app.static_folder is not None
+        return send_from_directory(app.static_folder, "index.html")
+
+    @app.route("/api/columns")
+    def columns() -> Any:  # pyright: ignore[reportUnusedFunction]
+        rows = con.execute("PRAGMA table_info(events)").fetchall()
+        return jsonify([{"name": r[1], "type": r[2]} for r in rows])
+
+    def _cache_get(key: Tuple[str, str]) -> List[str] | None:
+        item = sample_cache.get(key)
+        if item is None:
+            return None
+        vals, ts = item
+        if time.time() - ts > CACHE_TTL:
+            del sample_cache[key]
+            return None
+        sample_cache[key] = (vals, time.time())
+        return vals
+
+    def _cache_set(key: Tuple[str, str], vals: List[str]) -> None:
+        sample_cache[key] = (vals, time.time())
+        if len(sample_cache) > CACHE_LIMIT:
+            oldest = min(sample_cache.items(), key=lambda kv: kv[1][1])[0]
+            del sample_cache[oldest]
+
+    @app.route("/api/samples")
+    def sample_values() -> Any:  # pyright: ignore[reportUnusedFunction]
+        column = request.args.get("column")
+        substr = request.args.get("q", "")
+        if not column or column not in column_types:
+            return jsonify([])
+        ctype = column_types[column].upper()
+        if "CHAR" not in ctype and "STRING" not in ctype and "VARCHAR" not in ctype:
+            return jsonify([])
+        key = (column, substr)
+        cached = _cache_get(key)
+        if cached is not None:
+            return jsonify(cached)
+        rows = con.execute(
+            f"SELECT DISTINCT {column} FROM events WHERE CAST({column} AS VARCHAR) ILIKE '%' || ? || '%' LIMIT 20",
+            [substr],
+        ).fetchall()
+        values = [r[0] for r in rows]
+        _cache_set(key, values)
+        return jsonify(values)
+
+    @app.route("/api/query", methods=["POST"])
+    def query() -> Any:  # pyright: ignore[reportUnusedFunction]
+        payload = request.get_json(force=True)
+        params = QueryParams(
+            start=payload.get("start"),
+            end=payload.get("end"),
+            order_by=payload.get("order_by"),
+            order_dir=payload.get("order_dir", "ASC"),
+            limit=payload.get("limit"),
+            columns=payload.get("columns", []),
+            derived_columns=payload.get("derived_columns", {}),
+        )
+        for f in payload.get("filters", []):
+            params.filters.append(Filter(f["column"], f["op"], f.get("value")))
+        sql = build_query(params)
+        rows = con.execute(sql).fetchall()
+        return jsonify({"sql": sql, "rows": rows})
+
+    return app
+
+
+app = create_app()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Summary
- allow connecting to csv, sqlite and duckdb files via `create_app`
- implement database type inference based on extension
- add server tests for all supported database types

# Testing
- `ruff format scubaduck/server.py tests/test_server.py`
- `ruff check scubaduck/server.py tests/test_server.py`
- `pyright`
- `pytest -q`