### PR TITLE
feat(web): float column section controls

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -72,7 +72,13 @@
     #column_actions a {
       margin-left: 5px;
     }
-    .col-group a {
+    .col-group-header {
+      overflow: hidden;
+    }
+    .col-group-header .links {
+      float: right;
+    }
+    .col-group-header .links a {
       margin-left: 5px;
     }
     /* Column resizer removed */
@@ -218,15 +224,19 @@ fetch('/api/columns').then(r => r.json()).then(cols => {
     const div = document.createElement('div');
     div.className = 'col-group';
     const header = document.createElement('div');
-    header.textContent = g.name + ': ';
+    header.className = 'col-group-header';
+    header.appendChild(document.createTextNode(g.name + ': '));
+    const links = document.createElement('span');
+    links.className = 'links';
     const allBtn = document.createElement('a');
     allBtn.href = '#';
     allBtn.textContent = 'All';
     const noneBtn = document.createElement('a');
     noneBtn.href = '#';
     noneBtn.textContent = 'None';
-    header.appendChild(allBtn);
-    header.appendChild(noneBtn);
+    links.appendChild(allBtn);
+    links.appendChild(noneBtn);
+    header.appendChild(links);
     div.appendChild(header);
     const ul = document.createElement('ul');
     g.ul = ul;

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -275,6 +275,17 @@ def test_column_group_links(page: Any, server_url: str) -> None:
     assert tag == "A"
 
 
+def test_column_group_links_float_right(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#order_by option", state="attached")
+    page.click("text=Columns")
+    page.wait_for_selector("#column_groups .col-group .links", state="attached")
+    float_val = page.evaluate(
+        "getComputedStyle(document.querySelector('#column_groups .col-group .links')).float"
+    )
+    assert float_val == "right"
+
+
 def test_chip_dropdown_navigation(page: Any, server_url: str) -> None:
     page.goto(server_url)
     page.wait_for_selector("#order_by option", state="attached")


### PR DESCRIPTION
## Summary
- float column section All/None links right
- test column group header floats right

## Testing
- `ruff format`
- `ruff check`
- `pyright`
- `pytest -q`
