### PR TITLE
feat(ui): improve relative time dropdown

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -14,7 +14,6 @@
     .field label { width: 80px; text-align: right; margin-right: 5px; }
     .help { margin-left: 4px; cursor: help; }
     .rel-btn { margin-left: 4px; }
-    .rel-select { margin-left: 4px; }
     #tabs { display: flex; align-items: center; margin-bottom: 10px; }
     #tabs .tab { margin-right: 5px; background: none; border: 1px solid #ccc; padding: 4px 8px; cursor: pointer; width: 120px; text-align: center; box-sizing: border-box; }
     #tabs .tab.active { background: #eee; font-weight: bold; }
@@ -52,6 +51,10 @@
     #filters .chip-dropdown { position: absolute; left: 0; right: 0; top: 100%; background: white; border: 1px solid #ccc; max-height: 120px; overflow-y: auto; z-index: 10; display: none; }
     #filters .chip-dropdown div { padding: 2px 4px; cursor: pointer; }
     #filters .chip-dropdown div.highlight { background: #bde4ff; }
+    .rel-box { position: relative; display: flex; }
+    .rel-dropdown { position: absolute; left: 0; right: 0; top: 100%; background: white; border: 1px solid #ccc; z-index: 10; display: none; }
+    .rel-dropdown div { padding: 2px 4px; cursor: pointer; }
+    .rel-dropdown div:hover { background: #bde4ff; }
     #filters .filter button.remove {
       margin-left: 5px;
       width: 20px;
@@ -90,35 +93,40 @@
       <div id="settings" class="tab-content active">
         <div class="field">
           <label>Start<span class="help" title="Sets the start/end of the time range to query. Can be any kind of datetime string. For example: 'April 23, 2014' or 'yesterday'.">[?]</span></label>
-          <input id="start" type="text" />
-          <button type="button" class="rel-btn" data-target="start-select">&#9660;</button>
-          <select id="start-select" class="rel-select" data-input="start" style="display:none">
-            <option value="-1 hour">-1 hour</option>
-            <option value="-3 hours">-3 hours</option>
-            <option value="-12 hours">-12 hours</option>
-            <option value="-1 day">-1 day</option>
-            <option value="-3 days">-3 days</option>
-            <option value="-1 week">-1 week</option>
-            <option value="-1 fortnight">-1 fortnight</option>
-            <option value="-30 days">-30 days</option>
-            <option value="-90 days">-90 days</option>
-          </select>
+          <div class="rel-box">
+            <input id="start" type="text" />
+            <button type="button" class="rel-btn" data-target="start-select">&#9660;</button>
+            <div id="start-select" class="rel-dropdown" data-input="start">
+              <div data-value="-1 hour">-1 hour</div>
+              <div data-value="-3 hours">-3 hours</div>
+              <div data-value="-12 hours">-12 hours</div>
+              <div data-value="-1 day">-1 day</div>
+              <div data-value="-3 days">-3 days</div>
+              <div data-value="-1 week">-1 week</div>
+              <div data-value="-1 fortnight">-1 fortnight</div>
+              <div data-value="-30 days">-30 days</div>
+              <div data-value="-90 days">-90 days</div>
+            </div>
+          </div>
         </div>
         <div class="field">
           <label>End<span class="help" title="Sets the start/end of the time range to query. Can be any kind of datetime string. For example: 'April 23, 2014' or 'yesterday'.">[?]</span></label>
-          <input id="end" type="text" />
-          <button type="button" class="rel-btn" data-target="end-select">&#9660;</button>
-          <select id="end-select" class="rel-select" data-input="end" style="display:none">
-            <option value="-1 hour">-1 hour</option>
-            <option value="-3 hours">-3 hours</option>
-            <option value="-12 hours">-12 hours</option>
-            <option value="-1 day">-1 day</option>
-            <option value="-3 days">-3 days</option>
-            <option value="-1 week">-1 week</option>
-            <option value="-1 fortnight">-1 fortnight</option>
-            <option value="-30 days">-30 days</option>
-            <option value="-90 days">-90 days</option>
-          </select>
+          <div class="rel-box">
+            <input id="end" type="text" />
+            <button type="button" class="rel-btn" data-target="end-select">&#9660;</button>
+            <div id="end-select" class="rel-dropdown" data-input="end">
+              <div data-value="now">now</div>
+              <div data-value="-1 hour">-1 hour</div>
+              <div data-value="-3 hours">-3 hours</div>
+              <div data-value="-12 hours">-12 hours</div>
+              <div data-value="-1 day">-1 day</div>
+              <div data-value="-3 days">-3 days</div>
+              <div data-value="-1 week">-1 week</div>
+              <div data-value="-1 fortnight">-1 fortnight</div>
+              <div data-value="-30 days">-30 days</div>
+              <div data-value="-90 days">-90 days</div>
+            </div>
+          </div>
         </div>
         <div class="field">
           <label>Order By<span class="help" title="Choose a column to sort results by.">[?]</span></label>
@@ -282,15 +290,23 @@ document.querySelectorAll('#tabs .tab').forEach(btn => {
 
 document.querySelectorAll('.rel-btn').forEach(btn => {
   btn.addEventListener('click', () => {
-    const sel = document.getElementById(btn.dataset.target);
-    sel.style.display = sel.style.display === 'none' ? 'block' : 'none';
+    const dd = document.getElementById(btn.dataset.target);
+    const show = dd.style.display === 'none' || dd.style.display === '';
+    document.querySelectorAll('.rel-dropdown').forEach(d => (d.style.display = 'none'));
+    dd.style.display = show ? 'block' : 'none';
   });
 });
-document.querySelectorAll('.rel-select').forEach(sel => {
-  sel.addEventListener('change', () => {
-    const input = document.getElementById(sel.dataset.input);
-    input.value = sel.value;
-    sel.style.display = 'none';
+document.querySelectorAll('.rel-dropdown div').forEach(opt => {
+  opt.addEventListener('click', () => {
+    const box = opt.closest('.rel-box');
+    const input = box.querySelector('input');
+    input.value = opt.dataset.value || opt.textContent;
+    opt.parentElement.style.display = 'none';
+  });
+});
+document.addEventListener('click', e => {
+  document.querySelectorAll('.rel-dropdown').forEach(dd => {
+    if (!dd.parentElement.contains(e.target)) dd.style.display = 'none';
   });
 });
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -212,8 +212,16 @@ def test_relative_dropdown(page: Any, server_url: str) -> None:
     btn = page.query_selector('[data-target="start-select"]')
     assert btn
     btn.click()
-    page.select_option("#start-select", "-3 hours")
+    page.click("#start-select div:text('-3 hours')")
     assert page.input_value("#start") == "-3 hours"
+
+
+def test_end_dropdown_now(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#order_by option", state="attached")
+    page.click('[data-target="end-select"]')
+    page.click("#end-select div:text('now')")
+    assert page.input_value("#end") == "now"
 
 
 def test_column_toggle_and_selection(page: Any, server_url: str) -> None:


### PR DESCRIPTION
## Summary
- update relative time selectors with dropdown overlays
- add `now` option to end dropdown
- adjust event handling for new relative selectors
- cover new dropdown behavior in web tests

## Testing
- `ruff check`
- `pyright`
- `pytest -q`