### PR TITLE
feat(web): display message when query returns no data

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -765,7 +765,12 @@ function handleSort(e) {
 function showResults(data) {
   window.lastResults = data;
   const view = document.getElementById('view');
-  view.innerHTML = '<table id="results"></table>';
+  if (data.rows.length === 0) {
+    view.innerHTML =
+      '<p id="empty-message">Empty data provided to table</p><table id="results"></table>';
+  } else {
+    view.innerHTML = '<table id="results"></table>';
+  }
   originalRows = data.rows.slice();
   sortState = {index: null, dir: null};
   renderTable(originalRows);

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -482,3 +482,17 @@ def test_load_from_url(page: Any, server_url: str) -> None:
     assert page.input_value("#end") == "2024-01-02 00:00:00"
     assert page.input_value("#limit") == "2"
     assert page.evaluate("window.lastResults.rows.length") == 2
+
+
+def test_empty_data_message(page: Any, server_url: str) -> None:
+    data = run_query(
+        page,
+        server_url,
+        start="2025-01-01 00:00:00",
+        end="2025-01-02 00:00:00",
+        order_by="timestamp",
+        limit=100,
+    )
+    assert data["rows"] == []
+    msg = page.text_content("#view")
+    assert "Empty data provided to table" in msg


### PR DESCRIPTION
## Summary
- show an empty data message when query results return no rows
- test for empty data message

## Testing
- `ruff check scubaduck tests`
- `pyright`
- `pytest -q`