### PR TITLE
fix(server): support relative timestamps

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -640,10 +640,17 @@ function dive(push=true) {
   window.lastResults = undefined;
   queryStart = performance.now();
   fetch('/api/query', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload)})
-    .then(r=>r.json())
+    .then(async r => {
+      const data = await r.json();
+      if (!r.ok) throw new Error(data.error || 'Error');
+      return data;
+    })
     .then(data => {
       lastQueryTime = Math.round(performance.now() - queryStart);
       showResults(data);
+    })
+    .catch(err => {
+      showError(err.message);
     });
 }
 
@@ -873,6 +880,13 @@ function showResults(data) {
   renderTable(originalRows);
   document.getElementById('query_info').textContent =
     `Your query took about ${lastQueryTime} ms`;
+}
+
+function showError(msg) {
+  window.lastResults = {error: msg};
+  const view = document.getElementById('view');
+  view.innerHTML = `<p id="error-message">${msg}</p>`;
+  document.getElementById('query_info').textContent = '';
 }
 </script>
 </body>

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -235,6 +235,19 @@ def test_end_dropdown_now(page: Any, server_url: str) -> None:
     assert page.input_value("#end") == "now"
 
 
+def test_invalid_time_error_shown(page: Any, server_url: str) -> None:
+    data = run_query(
+        page,
+        server_url,
+        start="nonsense",
+        end="now",
+        order_by="timestamp",
+    )
+    assert "error" in data
+    msg = page.text_content("#view")
+    assert "nonsense" in msg
+
+
 def test_column_toggle_and_selection(page: Any, server_url: str) -> None:
     page.goto(server_url)
     page.wait_for_selector("#order_by option", state="attached")


### PR DESCRIPTION
## Summary
- handle relative times in query parameters
- surface query errors back to the client
- show errors in the UI
- test relative times and error handling

## Testing
- `ruff format scubaduck/server.py`
- `ruff check scubaduck/server.py`
- `pyright`
- `pytest -q`