### PR TITLE
feat(server): include SQL and traceback in query errors

### DIFF
--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 import time
 from pathlib import Path
 import sqlite3
+import traceback
 
 import duckdb
 from dateutil import parser as dtparser
@@ -253,7 +254,12 @@ def create_app(db_file: str | Path | None = None) -> Flask:
         try:
             rows = con.execute(sql).fetchall()
         except Exception as exc:
-            return jsonify({"sql": sql, "error": str(exc)}), 400
+            tb = traceback.format_exc()
+            print(f"Query failed:\n{sql}\n{tb}")
+            return (
+                jsonify({"sql": sql, "error": str(exc), "traceback": tb}),
+                400,
+            )
         return jsonify({"sql": sql, "rows": rows})
 
     return app

--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -642,7 +642,7 @@ function dive(push=true) {
   fetch('/api/query', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload)})
     .then(async r => {
       const data = await r.json();
-      if (!r.ok) throw new Error(data.error || 'Error');
+      if (!r.ok) throw data;
       return data;
     })
     .then(data => {
@@ -650,7 +650,7 @@ function dive(push=true) {
       showResults(data);
     })
     .catch(err => {
-      showError(err.message);
+      showError(err);
     });
 }
 
@@ -882,10 +882,22 @@ function showResults(data) {
     `Your query took about ${lastQueryTime} ms`;
 }
 
-function showError(msg) {
-  window.lastResults = {error: msg};
+function showError(err) {
+  window.lastResults = err;
   const view = document.getElementById('view');
-  view.innerHTML = `<p id="error-message">${msg}</p>`;
+  let msg = '';
+  if (typeof err === 'string') {
+    msg = err;
+  } else if (err) {
+    msg = err.error || 'Error';
+    if (err.sql) {
+      msg += '\nSQL: ' + err.sql;
+    }
+    if (err.traceback) {
+      msg += '\n' + err.traceback;
+    }
+  }
+  view.innerHTML = `<pre id="error-message">${msg}</pre>`;
   document.getElementById('query_info').textContent = '';
 }
 </script>

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -264,3 +264,23 @@ def test_invalid_time_error() -> None:
     data = rv.get_json()
     assert rv.status_code == 400
     assert "error" in data
+
+
+def test_query_error_returns_sql_and_traceback() -> None:
+    app = server.app
+    client = app.test_client()
+    payload = {
+        "start": "2024-01-01 00:00:00",
+        "end": "2024-01-03 00:00:00",
+        "columns": ["event"],
+        "group_by": ["user"],
+        "aggregate": "avg",
+    }
+    rv = client.post(
+        "/api/query", data=json.dumps(payload), content_type="application/json"
+    )
+    data = rv.get_json()
+    assert rv.status_code == 400
+    assert "sql" in data
+    assert "traceback" in data
+    assert "avg(event)" in data["sql"]


### PR DESCRIPTION
## Summary
- expose SQL and traceback when `/api/query` fails
- update error display on the frontend
- test query error handling

## Testing
- `ruff check scubaduck/server.py tests/test_server.py tests/test_web.py`
- `pyright`
- `pytest -k '' -q`