### PR TITLE
fix(web): improve group by chip input

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -146,10 +146,10 @@
         <div id="group_by_field" class="field" style="display:none;">
           <label>Group By</label>
           <div class="chip-box">
-            <div class="chip-input">
+          <div class="chip-input">
               <input id="group_by" class="f-val" type="text">
-              <button type="button" class="chip-copy">\u2398</button>
-            </div>
+              <button type="button" class="chip-copy">&#x2398;</button>
+          </div>
             <div class="chip-dropdown"></div>
           </div>
         </div>
@@ -543,24 +543,27 @@ function initChipInput(filter) {
 
   function loadOptions() {
     const colSel = filter.querySelector('.f-col');
-    if (!colSel) return;
-    const col = colSel.value;
-    if (!isStringColumn(col)) {
-      dropdown.innerHTML = '';
-      return;
+    if (colSel) {
+      const col = colSel.value;
+      if (!isStringColumn(col)) {
+        dropdown.innerHTML = '';
+        return;
+      }
+      fetch(`/api/samples?column=${encodeURIComponent(col)}&q=${encodeURIComponent(input.value)}`)
+        .then(r => r.json())
+        .then(data => {
+          options = data;
+          renderDropdown(options.slice());
+        });
+    } else if (filter === groupBy) {
+      const typed = input.value.toLowerCase();
+      const opts = allColumns.filter(c => c.toLowerCase().includes(typed));
+      renderDropdown(opts);
     }
-    fetch(`/api/samples?column=${encodeURIComponent(col)}&q=${encodeURIComponent(input.value)}`)
-      .then(r => r.json())
-      .then(data => {
-        options = data;
-        renderDropdown(options.slice());
-      });
   }
 
-  if (filter.querySelector('.f-col')) {
-    input.addEventListener('focus', loadOptions);
-    input.addEventListener('input', loadOptions);
-  }
+  input.addEventListener('focus', loadOptions);
+  input.addEventListener('input', loadOptions);
 
   document.addEventListener('click', evt => {
     if (!filter.contains(evt.target)) {
@@ -581,7 +584,7 @@ function addFilter() {
     <div class="chip-box">
       <div class="chip-input">
         <input class="f-val" type="text">
-        <button type="button" class="chip-copy">\u2398</button>
+        <button type="button" class="chip-copy">&#x2398;</button>
       </div>
       <div class="chip-dropdown"></div>
     </div>
@@ -711,7 +714,7 @@ function applyParams(params) {
   graphTypeSel.value = params.graph_type || 'samples';
   updateDisplayTypeUI();
   if (params.group_by) {
-    groupBy.chips = params.group_by.slice();
+    groupBy.chips.splice(0, groupBy.chips.length, ...params.group_by);
     groupBy.renderChips();
   }
   if (params.aggregate) document.getElementById('aggregate').value = params.aggregate;

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -520,3 +520,32 @@ def test_empty_data_message(page: Any, server_url: str) -> None:
     assert data["rows"] == []
     msg = page.text_content("#view")
     assert "Empty data provided to table" in msg
+
+
+def test_group_by_chip_from_url(page: Any, server_url: str) -> None:
+    url = f"{server_url}?graph_type=table&group_by=user&order_by=user&limit=10"
+    page.goto(url)
+    page.wait_for_selector("#group_by_field .chip", state="attached")
+    chips = page.evaluate(
+        "Array.from(document.querySelectorAll('#group_by_field .chip')).map(c => c.firstChild.textContent)"
+    )
+    assert chips == ["user"]
+
+
+def test_group_by_autocomplete(page: Any, server_url: str) -> None:
+    page.goto(f"{server_url}?graph_type=table")
+    page.wait_for_selector("#group_by_field", state="visible")
+    inp = page.query_selector("#group_by_field .f-val")
+    assert inp
+    inp.click()
+    page.keyboard.type("us")
+    page.wait_for_selector("#group_by_field .chip-dropdown div")
+    options = page.locator("#group_by_field .chip-dropdown div").all_inner_texts()
+    assert "user" in options
+
+
+def test_group_by_copy_icon(page: Any, server_url: str) -> None:
+    page.goto(f"{server_url}?graph_type=table")
+    page.wait_for_selector("#group_by_field", state="visible")
+    icon = page.text_content("#group_by_field .chip-copy")
+    assert icon == "⎘"


### PR DESCRIPTION
## Summary
- make group-by chip copy button show proper icon
- preserve chip values when loading from URL
- add column autocomplete to group-by input
- test the group-by chip functionality

## Testing
- `ruff check`
- `pyright`
- `pytest -q`