### PR TITLE
feat(web): add searchable dropdown component

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -55,6 +55,13 @@
     .rel-dropdown { position: absolute; left: 0; right: 0; top: 100%; background: white; border: 1px solid #ccc; z-index: 10; display: none; }
     .rel-dropdown div { padding: 2px 4px; cursor: pointer; }
     .rel-dropdown div:hover { background: #bde4ff; }
+    .dropdown { position: relative; display: inline-block; }
+    .dropdown-display { border: 1px solid #ccc; padding: 2px 18px 2px 4px; cursor: pointer; min-width: 80px; }
+    .dropdown-menu { position: absolute; left: 0; right: 0; top: 100%; background: white; border: 1px solid #ccc; z-index: 10; max-height: 160px; overflow-y: auto; display: none; }
+    .dropdown-menu input { width: 100%; box-sizing: border-box; padding: 2px 4px; border: none; border-bottom: 1px solid #ccc; }
+    .dropdown-menu div { padding: 2px 4px; cursor: pointer; }
+    .dropdown-menu div.selected { background: #bde4ff; }
+    .dropdown-menu div:hover { background: #eee; }
     #filters .filter button.remove {
       margin-left: 5px;
       width: 20px;
@@ -207,6 +214,75 @@ const timeColumns = [];
 let selectedColumns = [];
 let displayType = 'samples';
 let groupBy = {chips: [], addChip: () => {}, renderChips: () => {}};
+
+function initDropdown(select) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'dropdown';
+  select.parentNode.insertBefore(wrapper, select);
+  wrapper.appendChild(select);
+  select.style.display = 'none';
+  const disp = document.createElement('div');
+  disp.className = 'dropdown-display';
+  function updateDisplay() {
+    const opt = select.options[select.selectedIndex];
+    disp.textContent = opt ? opt.textContent : '';
+  }
+  updateDisplay();
+  wrapper.appendChild(disp);
+  const menu = document.createElement('div');
+  menu.className = 'dropdown-menu';
+  const search = document.createElement('input');
+  menu.appendChild(search);
+  const list = document.createElement('div');
+  menu.appendChild(list);
+  wrapper.appendChild(menu);
+
+  function close() {
+    menu.style.display = 'none';
+  }
+
+  function open() {
+    renderOptions();
+    menu.style.display = 'block';
+    search.focus();
+  }
+
+  disp.addEventListener('click', () => {
+    if (menu.style.display === 'block') {
+      close();
+    } else {
+      open();
+    }
+  });
+
+  document.addEventListener('click', e => {
+    if (!wrapper.contains(e.target)) {
+      close();
+    }
+  });
+
+  function renderOptions() {
+    const q = search.value.toLowerCase();
+    list.innerHTML = '';
+    Array.from(select.options).forEach(o => {
+      if (!o.textContent.toLowerCase().includes(q)) return;
+      const div = document.createElement('div');
+      div.textContent = o.textContent;
+      if (o.value === select.value) div.className = 'selected';
+      div.addEventListener('mousedown', evt => {
+        evt.preventDefault();
+        select.value = o.value;
+        select.dispatchEvent(new Event('change'));
+        updateDisplay();
+        close();
+      });
+      list.appendChild(div);
+    });
+  }
+
+  search.addEventListener('input', renderOptions);
+  select.addEventListener('change', updateDisplay);
+}
 // Sidebar resizing
 const sidebar = document.getElementById('sidebar');
 const sidebarResizer = document.getElementById('sidebar-resizer');
@@ -339,6 +415,9 @@ fetch('/api/columns').then(r => r.json()).then(cols => {
   updateSelectedColumns();
   groupBy = document.getElementById('group_by').closest('.field');
   initChipInput(groupBy);
+  initDropdown(orderSelect);
+  initDropdown(document.getElementById('aggregate'));
+  initDropdown(graphTypeSel);
   updateDisplayTypeUI();
   addFilter();
   initFromUrl();
@@ -591,6 +670,7 @@ function addFilter() {
   `;
   const colSel = container.querySelector('.f-col');
   colSel.innerHTML = allColumns.map(c => `<option value="${c}">${c}</option>`).join('');
+  initDropdown(colSel);
 
   function populateOps() {
     const opSel = container.querySelector('.f-op');
@@ -625,6 +705,7 @@ function addFilter() {
 
   colSel.addEventListener('change', populateOps);
   container.querySelector('.f-op').addEventListener('change', updateInputVis);
+  initDropdown(container.querySelector('.f-op'));
   populateOps();
   document.getElementById('filter_list').appendChild(container);
   initChipInput(container);
@@ -902,6 +983,14 @@ function showError(err) {
   }
   view.innerHTML = `<pre id="error-message">${msg}</pre>`;
   document.getElementById('query_info').textContent = '';
+}
+
+function setSelectValue(selector, value) {
+  const el = typeof selector === 'string' ? document.querySelector(selector) : selector;
+  if (el) {
+    el.value = value;
+    el.dispatchEvent(new Event('change'));
+  }
 }
 </script>
 </body>

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3,6 +3,13 @@ from __future__ import annotations
 from typing import Any
 
 
+def select_value(page: Any, selector: str, value: str) -> None:
+    page.evaluate(
+        "arg => setSelectValue(arg.sel, arg.val)",
+        {"sel": selector, "val": value},
+    )
+
+
 def run_query(
     page: Any,
     url: str,
@@ -24,20 +31,20 @@ def run_query(
     if end is not None:
         page.fill("#end", end)
     if order_by is not None:
-        page.select_option("#order_by", order_by)
+        select_value(page, "#order_by", order_by)
     if order_dir is not None and order_dir == "DESC":
         page.click("#order_dir")
     if limit is not None:
         page.fill("#limit", str(limit))
     if group_by is not None:
-        page.select_option("#graph_type", "table")
+        select_value(page, "#graph_type", "table")
         page.evaluate(
             "g => { groupBy.chips = g; groupBy.renderChips(); }",
             group_by,
         )
     if aggregate is not None:
-        page.select_option("#graph_type", "table")
-        page.select_option("#aggregate", aggregate)
+        select_value(page, "#graph_type", "table")
+        select_value(page, "#aggregate", aggregate)
     page.evaluate("window.lastResults = undefined")
     page.click("text=Dive")
     page.wait_for_function("window.lastResults !== undefined")
@@ -95,7 +102,10 @@ def test_simple_filter(page: Any, server_url: str) -> None:
     page.click("text=Add Filter")
     filter_el = page.query_selector("#filters .filter:last-child")
     assert filter_el
-    filter_el.query_selector(".f-col").select_option("user")
+    page.evaluate(
+        "arg => setSelectValue(arg.el.querySelector('.f-col'), arg.val)",
+        {"el": filter_el, "val": "user"},
+    )
     val_input = filter_el.query_selector(".f-val")
     val_input.click()
     page.keyboard.type("alice")
@@ -158,7 +168,7 @@ def test_header_and_tabs(page: Any, server_url: str) -> None:
 def test_graph_type_table_fields(page: Any, server_url: str) -> None:
     page.goto(server_url)
     page.wait_for_selector("#graph_type", state="attached")
-    page.select_option("#graph_type", "table")
+    select_value(page, "#graph_type", "table")
     assert page.is_visible("#group_by_field")
     assert page.is_visible("#aggregate_field")
     assert page.is_visible("#show_hits_field")
@@ -302,7 +312,7 @@ def test_column_toggle_and_selection(page: Any, server_url: str) -> None:
     page.click("text=View Settings")
     page.fill("#start", "2024-01-01 00:00:00")
     page.fill("#end", "2024-01-02 00:00:00")
-    page.select_option("#order_by", "timestamp")
+    select_value(page, "#order_by", "timestamp")
     page.fill("#limit", "10")
     page.evaluate("window.lastResults = undefined")
     page.click("text=Dive")
@@ -352,7 +362,10 @@ def test_chip_dropdown_navigation(page: Any, server_url: str) -> None:
     page.click("text=Add Filter")
     f = page.query_selector("#filters .filter:last-child")
     assert f
-    f.query_selector(".f-col").select_option("user")
+    page.evaluate(
+        "arg => setSelectValue(arg.el.querySelector('.f-col'), arg.val)",
+        {"el": f, "val": "user"},
+    )
     inp = f.query_selector(".f-val")
     inp.click()
     page.wait_for_selector("#filters .filter:last-child .chip-dropdown div")
@@ -377,7 +390,10 @@ def test_chip_copy_and_paste(page: Any, server_url: str) -> None:
     page.click("text=Add Filter")
     f = page.query_selector("#filters .filter:last-child")
     assert f
-    f.query_selector(".f-col").select_option("user")
+    page.evaluate(
+        "arg => setSelectValue(arg.el.querySelector('.f-col'), arg.val)",
+        {"el": f, "val": "user"},
+    )
     inp = f.query_selector(".f-val")
     inp.click()
     page.keyboard.type("alice")
@@ -418,7 +434,10 @@ def test_chip_dropdown_hides_on_outside_click(page: Any, server_url: str) -> Non
     page.click("text=Add Filter")
     f = page.query_selector("#filters .filter:last-child")
     assert f
-    f.query_selector(".f-col").select_option("user")
+    page.evaluate(
+        "arg => setSelectValue(arg.el.querySelector('.f-col'), arg.val)",
+        {"el": f, "val": "user"},
+    )
     inp = f.query_selector(".f-val")
     inp.click()
     page.wait_for_selector("#filters .filter:last-child .chip-dropdown div")


### PR DESCRIPTION
## Summary
- implement custom searchable dropdowns in index.html
- update filters and existing selects to use new widget
- expose `setSelectValue` helper for tests
- update tests to use new helper

## Testing
- `ruff check`
- `pyright`
- `pytest`