### PR TITLE
fix(server): allow avg on timestamp

### DIFF
--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -283,10 +283,10 @@ def create_app(db_file: str | Path | None = None) -> Flask:
 
         if params.group_by:
             agg = (params.aggregate or "avg").lower()
-            if agg.startswith("p") or agg in {"avg", "sum"}:
+            if agg.startswith("p") or agg == "sum":
                 need_numeric = True
                 allow_time = False
-            elif agg in {"min", "max"}:
+            elif agg == "avg" or agg in {"min", "max"}:
                 need_numeric = False
                 allow_time = True
             else:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -269,7 +269,7 @@ def test_invalid_time_error_shown(page: Any, server_url: str) -> None:
     assert "nonsense" in msg
 
 
-def test_query_error_shown(page: Any, server_url: str) -> None:
+def test_table_avg_group_by(page: Any, server_url: str) -> None:
     data = run_query(
         page,
         server_url,
@@ -279,9 +279,8 @@ def test_query_error_shown(page: Any, server_url: str) -> None:
         group_by=["user"],
         aggregate="Avg",
     )
-    assert "error" in data
-    msg = page.text_content("#view")
-    assert "Aggregate avg" in msg
+    assert "error" not in data
+    assert len(data["rows"]) == 3
 
 
 def test_column_toggle_and_selection(page: Any, server_url: str) -> None:


### PR DESCRIPTION
## Summary
- fix averaging timestamp fields in group-by queries
- test avg with timestamp and grouping
- update frontend test to check group-by avg query works

## Testing
- `ruff check scubaduck/server.py tests/test_server.py tests/test_web.py`
- `pyright`
- `pytest -q`