### PR TITLE
feat(web): show aggregate name in table headers

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -875,12 +875,22 @@ function renderTable(rows) {
   const header = document.createElement('tr');
   selectedColumns.forEach((col, i) => {
     const th = document.createElement('th');
-    th.textContent = col;
+    let label = col;
+    if (
+      displayType === 'table' &&
+      col !== 'Hits' &&
+      !(groupBy.chips || []).includes(col)
+    ) {
+      const agg = document.getElementById('aggregate').value.toLowerCase();
+      label += ` (${agg})`;
+    }
+    th.textContent = label;
     th.dataset.index = i;
     th.addEventListener('click', handleSort);
     if (sortState.index === i) {
       th.classList.add('sorted');
-      th.textContent = col + (sortState.dir === 'desc' ? ' \u25BC' : ' \u25B2');
+      th.textContent =
+        label + (sortState.dir === 'desc' ? ' \u25BC' : ' \u25B2');
     }
     if (!isStringColumn(col)) th.style.textAlign = 'right';
     header.appendChild(th);

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -634,3 +634,15 @@ def test_table_avg_no_group_by(page: Any, server_url: str) -> None:
     ts = parser.parse(row[1]).replace(tzinfo=None)
     assert ts == parser.parse("2024-01-01 13:00:00")
     assert row[2] == 25
+
+
+def test_table_headers_show_aggregate(page: Any, server_url: str) -> None:
+    run_query(
+        page,
+        server_url,
+        aggregate="Avg",
+    )
+    headers = page.locator("#results th").all_inner_texts()
+    assert "Hits" in headers
+    assert "timestamp (avg)" in headers
+    assert "value (avg)" in headers


### PR DESCRIPTION
## Summary
- display aggregate in table column headers
- test that table headers include selected aggregate

## Testing
- `ruff check`
- `pyright`
- `pytest -q`