### PR TITLE
feat(web): toggle chip on repeat selection

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -551,8 +551,7 @@ function initChipInput(filter, fetchOptions) {
   const chipsEl = filter.querySelector('.chip-input');
   const dropdown = filter.querySelector('.chip-dropdown');
   const copyBtn = filter.querySelector('.chip-copy');
-  const chips = [];
-  filter.chips = chips;
+  filter.chips = [];
   filter.renderChips = renderChips;
   filter.addChip = addChip;
   let highlight = 0;
@@ -564,7 +563,7 @@ function initChipInput(filter, fetchOptions) {
 
     function renderChips() {
       chipsEl.querySelectorAll('.chip').forEach(c => c.remove());
-      chips.forEach((v, i) => {
+      filter.chips.forEach((v, i) => {
         const span = document.createElement('span');
         span.className = 'chip';
         span.textContent = v;
@@ -573,7 +572,7 @@ function initChipInput(filter, fetchOptions) {
         x.textContent = '✖';
         x.addEventListener('click', e => {
           e.stopPropagation();
-          chips.splice(i, 1);
+          filter.chips.splice(i, 1);
           renderChips();
           input.focus();
         });
@@ -601,13 +600,18 @@ function initChipInput(filter, fetchOptions) {
 
   function addChip(val) {
     if (!val) return;
-    chips.push(val);
+    const i = filter.chips.indexOf(val);
+    if (i !== -1) {
+      filter.chips.splice(i, 1);
+    } else {
+      filter.chips.push(val);
+    }
     input.value = '';
     renderChips();
   }
 
   copyBtn.addEventListener('click', () => {
-    navigator.clipboard && navigator.clipboard.writeText(chips.join(','));
+    navigator.clipboard && navigator.clipboard.writeText(filter.chips.join(','));
   });
 
   input.addEventListener('paste', e => {
@@ -635,8 +639,8 @@ function initChipInput(filter, fetchOptions) {
       }
       e.preventDefault();
     } else if (e.key === 'Backspace' && input.value === '') {
-      if (chips.length > 0) {
-        chips.pop();
+      if (filter.chips.length > 0) {
+        filter.chips.pop();
         renderChips();
       }
     } else if (e.key === 'Enter') {

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -594,6 +594,33 @@ def test_chip_backspace_keeps_dropdown(page: Any, server_url: str) -> None:
     assert visible == "block"
 
 
+def test_chip_duplicate_toggles(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#order_by option", state="attached")
+    page.click("text=Add Filter")
+    f = page.query_selector("#filters .filter:last-child")
+    assert f
+    page.evaluate(
+        "arg => setSelectValue(arg.el.querySelector('.f-col'), arg.val)",
+        {"el": f, "val": "user"},
+    )
+    inp = f.query_selector(".f-val")
+    inp.click()
+    page.keyboard.type("alice")
+    page.keyboard.press("Enter")
+    chips = page.evaluate(
+        "Array.from(document.querySelectorAll('#filters .filter:last-child .chip')).map(c => c.firstChild.textContent)"
+    )
+    assert chips == ["alice"]
+    inp.click()
+    page.keyboard.type("alice")
+    page.keyboard.press("Enter")
+    chips = page.evaluate(
+        "Array.from(document.querySelectorAll('#filters .filter:last-child .chip')).map(c => c.firstChild.textContent)"
+    )
+    assert chips == []
+
+
 def test_table_enhancements(page: Any, server_url: str) -> None:
     run_query(
         page,


### PR DESCRIPTION
## Summary
- when adding chips, toggle duplicates instead of always appending
- test chip removal when selecting an existing chip again

## Testing
- `ruff check`
- `pyright`
- `pytest -q`