### PR TITLE
fix: handle timeseries avg on strings

### DIFF
--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -342,7 +342,7 @@ def create_app(db_file: str | Path | None = None) -> Flask:
         if params.order_by and params.order_by not in valid_cols:
             return jsonify({"error": f"Unknown column: {params.order_by}"}), 400
 
-        if params.group_by:
+        if params.group_by or params.graph_type == "timeseries":
             agg = (params.aggregate or "avg").lower()
             if agg.startswith("p") or agg == "sum":
                 need_numeric = True

--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -404,6 +404,13 @@ function updateDisplayTypeUI() {
     if (!lim.dataset.setByUser) {
       lim.value = '7';
     }
+    document.querySelectorAll('#column_groups input').forEach(cb => {
+      if (isTimeColumn(cb.value) || isStringColumn(cb.value)) {
+        cb.checked = false;
+      }
+    });
+    document.getElementById('order_by').value = '';
+    updateSelectedColumns();
   }
   displayType = graphTypeSel.value;
 }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -368,3 +368,23 @@ def test_timeseries_basic() -> None:
     data = rv.get_json()
     assert rv.status_code == 200
     assert len(data["rows"]) == 4
+
+
+def test_timeseries_string_column_error() -> None:
+    app = server.app
+    client = app.test_client()
+    payload = {
+        "start": "2024-01-01 00:00:00",
+        "end": "2024-01-03 00:00:00",
+        "graph_type": "timeseries",
+        "limit": 7,
+        "columns": ["timestamp", "event", "value", "user"],
+        "x_axis": "timestamp",
+        "granularity": "1 hour",
+    }
+    rv = client.post(
+        "/api/query", data=json.dumps(payload), content_type="application/json"
+    )
+    data = rv.get_json()
+    assert rv.status_code == 400
+    assert "Aggregate" in data["error"]

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -196,6 +196,20 @@ def test_graph_type_timeseries_fields(page: Any, server_url: str) -> None:
     assert page.is_visible("#fill_field")
 
 
+def test_timeseries_default_query(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#graph_type", state="attached")
+    select_value(page, "#graph_type", "timeseries")
+    page.evaluate("window.lastResults = undefined")
+    page.click("text=Dive")
+    page.wait_for_function("window.lastResults !== undefined")
+    data = page.evaluate("window.lastResults")
+    assert "error" not in data
+    assert page.is_visible("#chart")
+    page.click("text=Columns")
+    assert not page.is_checked("#column_groups input[value='timestamp']")
+
+
 def test_help_and_alignment(page: Any, server_url: str) -> None:
     page.goto(server_url)
     page.wait_for_selector("#order_by option", state="attached")


### PR DESCRIPTION
## Summary
- fail gracefully when timeseries AVG applies to strings
- default to deselecting non-numeric columns when switching to Time Series
- add regression tests for server and frontend

## Testing
- `ruff check`
- `ruff format`
- `pyright`
- `pytest -q`