### PR TITLE
fix(web): handle single-bucket timeseries

### DIFF
--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -149,7 +149,10 @@ def build_query(params: QueryParams, column_types: Dict[str, str] | None = None)
         group_cols = ["bucket"] + group_cols
     has_agg = bool(group_cols) or params.aggregate is not None
     if has_agg:
-        select_parts.extend(group_cols)
+        select_cols = (
+            group_cols[1:] if params.graph_type == "timeseries" else group_cols
+        )
+        select_parts.extend(select_cols)
         agg = (params.aggregate or "avg").lower()
 
         def agg_expr(col: str) -> str:

--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -1274,8 +1274,10 @@ function showTimeSeries(data) {
   });
   const colors = ['#1f77b4','#ff7f0e','#2ca02c','#d62728','#9467bd','#8c564b','#e377c2'];
   let colorIndex = 0;
-  const xScale = x => ((x - minX) / (maxX - minX)) * (width - 60) + 50;
-  const yScale = y => height - 30 - ((y - minY) / (maxY - minY)) * (height - 60);
+  const xRange = maxX - minX || 1;
+  const yRange = maxY - minY || 1;
+  const xScale = x => ((x - minX) / xRange) * (width - 60) + 50;
+  const yScale = y => height - 30 - ((y - minY) / yRange) * (height - 60);
   Object.keys(series).forEach(key => {
     const pts = series[key];
     const color = colors[colorIndex++ % colors.length];

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -210,6 +210,19 @@ def test_timeseries_default_query(page: Any, server_url: str) -> None:
     assert not page.is_checked("#column_groups input[value='timestamp']")
 
 
+def test_timeseries_single_bucket(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#graph_type", state="attached")
+    page.fill("#start", "2024-01-01 00:00:00")
+    page.fill("#end", "2024-01-01 00:00:00")
+    select_value(page, "#graph_type", "timeseries")
+    page.evaluate("window.lastResults = undefined")
+    page.click("text=Dive")
+    page.wait_for_function("window.lastResults !== undefined")
+    path = page.get_attribute("#chart path", "d")
+    assert path is not None and "NaN" not in path
+
+
 def test_help_and_alignment(page: Any, server_url: str) -> None:
     page.goto(server_url)
     page.wait_for_selector("#order_by option", state="attached")


### PR DESCRIPTION
## Summary
- avoid duplicate bucket column when building timeseries queries
- guard SVG scaling against zero range so we don't render NaN
- test single bucket timeseries

## Testing
- `ruff check`
- `pyright`
- `pytest -q`
