### PR TITLE
feat(server): sort timeseries queries

### DIFF
--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -219,6 +219,8 @@ def build_query(params: QueryParams, column_types: Dict[str, str] | None = None)
         query += " GROUP BY " + ", ".join(group_cols)
     if params.order_by:
         query += f" ORDER BY {params.order_by} {params.order_dir}"
+    elif params.graph_type == "timeseries":
+        query += " ORDER BY bucket"
     if params.limit is not None:
         query += f" LIMIT {params.limit}"
     return query

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -370,6 +370,30 @@ def test_timeseries_basic() -> None:
     assert len(data["rows"]) == 4
 
 
+def test_timeseries_orders_by_xaxis() -> None:
+    app = server.app
+    client = app.test_client()
+    payload = {
+        "start": "2024-01-01 00:00:00",
+        "end": "2024-01-03 00:00:00",
+        "graph_type": "timeseries",
+        "limit": 100,
+        "columns": ["value"],
+        "x_axis": "timestamp",
+        "granularity": "1 day",
+    }
+    rv = client.post(
+        "/api/query", data=json.dumps(payload), content_type="application/json"
+    )
+    data = rv.get_json()
+    assert rv.status_code == 200
+    rows = data["rows"]
+    from dateutil import parser
+
+    timestamps = [parser.parse(r[0]).replace(tzinfo=None) for r in rows]
+    assert timestamps == sorted(timestamps)
+
+
 def test_timeseries_string_column_error() -> None:
     app = server.app
     client = app.test_client()


### PR DESCRIPTION
## Summary
- add default ordering for timeseries queries
- verify ordering behaviour in server tests

## Testing
- `ruff check scubaduck tests`
- `pyright`
- `pytest -q`