### PR TITLE
feat(web): show SQL query under results

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -1147,6 +1147,12 @@ function showResults(data) {
     sortState = {index: null, dir: null};
     renderTable(originalRows);
   }
+  const sqlEl = document.createElement('pre');
+  sqlEl.id = 'sql_query';
+  sqlEl.style.whiteSpace = 'pre-wrap';
+  sqlEl.style.marginTop = '10px';
+  sqlEl.textContent = data.sql;
+  view.appendChild(sqlEl);
   document.getElementById('query_info').textContent =
     `Your query took about ${lastQueryTime} ms`;
 }

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -877,3 +877,18 @@ def test_derived_column_query(page: Any, server_url: str) -> None:
     page.wait_for_function("window.lastResults !== undefined")
     data = page.evaluate("window.lastResults")
     assert data["rows"][0][-1] == 20
+
+
+def test_sql_query_display(page: Any, server_url: str) -> None:
+    data = run_query(
+        page,
+        server_url,
+        start="2024-01-01 00:00:00",
+        end="2024-01-02 00:00:00",
+        order_by="timestamp",
+        limit=10,
+    )
+    sql = data["sql"]
+    displayed = page.text_content("#sql_query")
+    assert displayed is not None
+    assert displayed.strip() == sql


### PR DESCRIPTION
## Summary
- show executed SQL query under result table or chart
- add browser test for showing SQL

## Testing
- `ruff check scubaduck tests`
- `pyright`
- `pytest -q`