### PR TITLE
feat(ui): allow removing derived columns

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -44,6 +44,14 @@
       margin-left: 5px;
       flex: 1;
     }
+    #derived_columns .derived-row button.remove {
+      margin-left: 5px;
+      width: 20px;
+      flex: 0 0 auto;
+      padding: 0;
+      text-align: center;
+      line-height: 1;
+    }
     #derived_columns textarea {
       width: 100%;
       box-sizing: border-box;
@@ -743,6 +751,7 @@ function addDerived(data = {}) {
         <option value="numeric">Numeric</option>
       </select>
       <input class="d-name" type="text">
+      <button type="button" class="remove" onclick="removeDerived(this)">✖</button>
     </div>
     <label><input type="checkbox" class="d-use" checked> Include in Query</label>
     <textarea class="d-expr" rows="2"></textarea>
@@ -763,6 +772,16 @@ function addDerived(data = {}) {
     container.addEventListener(evt, refreshDerivedColumns);
   });
   derivedColumns.push(obj);
+  refreshDerivedColumns();
+}
+
+function removeDerived(btn) {
+  const el = btn.closest('.derived');
+  const idx = derivedColumns.findIndex(d => d.el === el);
+  if (idx !== -1) {
+    derivedColumns.splice(idx, 1);
+  }
+  el.remove();
   refreshDerivedColumns();
 }
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -877,3 +877,14 @@ def test_derived_column_query(page: Any, server_url: str) -> None:
     page.wait_for_function("window.lastResults !== undefined")
     data = page.evaluate("window.lastResults")
     assert data["rows"][0][-1] == 20
+
+
+def test_derived_column_remove(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#order_by option", state="attached")
+    page.click("text=Columns")
+    page.click("text=Add Derived")
+    assert page.query_selector("#derived_list .derived button.remove")
+    page.click("#derived_list .derived button.remove")
+    count = page.evaluate("document.querySelectorAll('#derived_list .derived').length")
+    assert count == 0


### PR DESCRIPTION
## Summary
- add remove button to derived columns
- expose removal logic in frontend
- test ability to delete derived columns

## Testing
- `ruff check`
- `pyright`
- `pytest -q`