### PR TITLE
feat(server): read database path from envvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,15 @@ LIMIT number
 ```
 
 You should write tests for the server backend, demonstrating that at specific query values we get back the correct rows of data.
+
+## Running the server
+
+Activate the virtual environment and run the Flask development server:
+
+```bash
+flask --app scubaduck.server run --debug
+```
+
+By default the server loads `sample.csv`. Set the `SCUBADUCK_DB` environment
+variable to point at a different database file (CSV, SQLite or DuckDB) if you
+want to use another dataset.

--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 
 import time
 from pathlib import Path
+import os
 import sqlite3
 import traceback
 
@@ -228,6 +229,10 @@ def build_query(params: QueryParams, column_types: Dict[str, str] | None = None)
 
 def create_app(db_file: str | Path | None = None) -> Flask:
     app = Flask(__name__, static_folder="static")
+    if db_file is None:
+        env_db = os.environ.get("SCUBADUCK_DB")
+        if env_db:
+            db_file = env_db
     db_path = Path(db_file or Path(__file__).with_name("sample.csv")).resolve()
     con = _load_database(db_path)
     column_types: Dict[str, str] = {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -200,6 +200,20 @@ def test_database_types(tmp_path: Path) -> None:
         assert len(rows) == 3
 
 
+def test_envvar_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    csv_file = tmp_path / "custom.csv"
+    csv_file.write_text("timestamp,event,value,user\n2024-01-01 00:00:00,login,5,bob\n")
+    monkeypatch.setenv("SCUBADUCK_DB", str(csv_file))
+    app = server.create_app()
+    client = app.test_client()
+    payload = _make_payload()
+    rv = client.post(
+        "/api/query", data=json.dumps(payload), content_type="application/json"
+    )
+    rows = rv.get_json()["rows"]
+    assert len(rows) == 1
+
+
 def test_group_by_table() -> None:
     app = server.app
     client = app.test_client()


### PR DESCRIPTION
## Summary
- allow `create_app` to load database path from `SCUBADUCK_DB`
- document running the app with Flask and the new envvar
- test envvar support

## Testing
- `ruff format scubaduck/server.py tests/test_server.py`
- `ruff check scubaduck/server.py tests/test_server.py`
- `pyright`
- `pytest -q`