### PR TITLE
fix(server): error on missing db file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,5 @@ flask --app scubaduck.server run --debug
 
 By default the server loads `sample.csv`. Set the `SCUBADUCK_DB` environment
 variable to point at a different database file (CSV, SQLite or DuckDB) if you
-want to use another dataset.
+want to use another dataset. If the file does not exist, the server will raise
+a `FileNotFoundError` during startup.

--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -44,6 +44,9 @@ class QueryParams:
 
 
 def _load_database(path: Path) -> duckdb.DuckDBPyConnection:
+    if not path.exists():
+        raise FileNotFoundError(path)
+
     ext = path.suffix.lower()
     if ext == ".csv":
         con = duckdb.connect()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -214,6 +214,13 @@ def test_envvar_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     assert len(rows) == 1
 
 
+def test_envvar_db_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    missing = tmp_path / "missing.sqlite"
+    monkeypatch.setenv("SCUBADUCK_DB", str(missing))
+    with pytest.raises(FileNotFoundError):
+        server.create_app()
+
+
 def test_group_by_table() -> None:
     app = server.app
     client = app.test_client()


### PR DESCRIPTION
## Summary
- raise FileNotFoundError when database file is missing
- test missing db path through SCUBADUCK_DB
- document FileNotFoundError in README

## Testing
- `ruff check --quiet`
- `pyright`
- `pytest -q`
