### PR TITLE
feat(timeseries): handle bucket gaps and auto-range

### DIFF
--- a/scubaduck/static/js/timeseries_chart.js
+++ b/scubaduck/static/js/timeseries_chart.js
@@ -16,22 +16,57 @@ function showTimeSeries(data) {
   const legend = document.getElementById('legend');
   const groups = groupBy.chips || [];
   const hasHits = document.getElementById('show_hits').checked ? 1 : 0;
+  const fill = document.getElementById('fill').value;
+  const bucketMs = (data.bucket_size || 3600) * 1000;
+  const start = data.start ? new Date(data.start).getTime() : null;
+  const end = data.end ? new Date(data.end).getTime() : null;
   const series = {};
-  let minX = Infinity,
-    maxX = -Infinity,
-    minY = Infinity,
-    maxY = -Infinity;
   data.rows.forEach(r => {
     const ts = new Date(r[0]).getTime();
     const key = groups.map((_, i) => r[1 + i]).join(':') || 'all';
     const val = Number(r[1 + groups.length + hasHits]);
-    if (!series[key]) series[key] = [];
-    series[key].push({ x: ts, y: val });
-    if (ts < minX) minX = ts;
-    if (ts > maxX) maxX = ts;
-    if (val < minY) minY = val;
-    if (val > maxY) maxY = val;
+    if (!series[key]) series[key] = {};
+    series[key][ts] = val;
   });
+
+  const buckets = [];
+  let minX = start !== null ? start : Infinity;
+  let maxX = end !== null ? end : -Infinity;
+  if (start !== null && end !== null) {
+    for (let t = start; t <= end; t += bucketMs) {
+      buckets.push(t);
+    }
+  } else {
+    Object.keys(series).forEach(k => {
+      const s = series[k];
+      Object.keys(s).forEach(t => {
+        const n = Number(t);
+        if (n < minX) minX = n;
+        if (n > maxX) maxX = n;
+      });
+    });
+    for (let t = minX; t <= maxX; t += bucketMs) {
+      buckets.push(t);
+    }
+  }
+
+  let minY = Infinity,
+    maxY = -Infinity;
+  Object.keys(series).forEach(key => {
+    const vals = series[key];
+    buckets.forEach(b => {
+      const v = vals[b];
+      const val = v === undefined && fill === '0' ? 0 : v;
+      if (val === undefined) return;
+      if (val < minY) minY = val;
+      if (val > maxY) maxY = val;
+    });
+  });
+  if (fill === '0') {
+    if (minY > 0) minY = 0;
+    if (maxY < 0) maxY = 0;
+  }
+
   const colors = [
     '#1f77b4',
     '#ff7f0e',
@@ -39,21 +74,40 @@ function showTimeSeries(data) {
     '#d62728',
     '#9467bd',
     '#8c564b',
-    '#e377c2',
+    '#e377c2'
   ];
   let colorIndex = 0;
   const xRange = maxX - minX || 1;
   const yRange = maxY - minY || 1;
   const xScale = x => ((x - minX) / xRange) * (width - 60) + 50;
   const yScale = y => height - 30 - ((y - minY) / yRange) * (height - 60);
+
   Object.keys(series).forEach(key => {
-    const pts = series[key];
+    const vals = series[key];
     const color = colors[colorIndex++ % colors.length];
-    const path = pts
-      .map((p, i) => (i === 0 ? 'M' : 'L') + xScale(p.x) + ' ' + yScale(p.y))
-      .join(' ');
+    let path = '';
+    let drawing = false;
+    buckets.forEach(b => {
+      const v = vals[b];
+      if (v === undefined) {
+        if (fill === '0') {
+          const x = xScale(b);
+          const y = yScale(0);
+          path += (drawing ? 'L' : 'M') + x + ' ' + y + ' ';
+          drawing = true;
+        } else if (fill === 'blank') {
+          drawing = false;
+        }
+        // connect: do nothing
+      } else {
+        const x = xScale(b);
+        const y = yScale(v);
+        path += (drawing ? 'L' : 'M') + x + ' ' + y + ' ';
+        drawing = true;
+      }
+    });
     const el = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-    el.setAttribute('d', path);
+    el.setAttribute('d', path.trim());
     el.setAttribute('fill', 'none');
     el.setAttribute('stroke', color);
     svg.appendChild(el);

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -474,3 +474,20 @@ def test_timeseries_derived_column() -> None:
     assert rv.status_code == 200
     rows = data["rows"]
     assert all(r[2] == r[1] * 2 for r in rows)
+
+
+def test_default_start_end_returned() -> None:
+    app = server.app
+    client = app.test_client()
+    payload = {
+        "order_by": "timestamp",
+        "limit": 5,
+        "columns": ["timestamp"],
+    }
+    rv = client.post(
+        "/api/query", data=json.dumps(payload), content_type="application/json"
+    )
+    data = rv.get_json()
+    assert rv.status_code == 200
+    assert data["start"] == "2024-01-01 00:00:00"
+    assert data["end"] == "2024-01-02 03:00:00"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -223,6 +223,36 @@ def test_timeseries_single_bucket(page: Any, server_url: str) -> None:
     assert path is not None and "NaN" not in path
 
 
+def test_timeseries_fill_options(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#graph_type", state="attached")
+    page.fill("#start", "2024-01-01 00:00:00")
+    page.fill("#end", "2024-01-02 03:00:00")
+    select_value(page, "#graph_type", "timeseries")
+    select_value(page, "#granularity", "1 hour")
+
+    select_value(page, "#fill", "0")
+    page.evaluate("window.lastResults = undefined")
+    page.click("text=Dive")
+    page.wait_for_function("window.lastResults !== undefined")
+    path_zero = page.get_attribute("#chart path", "d")
+    assert path_zero is not None and path_zero.count("L") > 20
+
+    select_value(page, "#fill", "connect")
+    page.evaluate("window.lastResults = undefined")
+    page.click("text=Dive")
+    page.wait_for_function("window.lastResults !== undefined")
+    path_conn = page.get_attribute("#chart path", "d")
+    assert path_conn is not None and path_conn.count("M") == 1
+
+    select_value(page, "#fill", "blank")
+    page.evaluate("window.lastResults = undefined")
+    page.click("text=Dive")
+    page.wait_for_function("window.lastResults !== undefined")
+    path_blank = page.get_attribute("#chart path", "d")
+    assert path_blank is not None and path_blank.count("M") > 1
+
+
 def test_help_and_alignment(page: Any, server_url: str) -> None:
     page.goto(server_url)
     page.wait_for_selector("#order_by option", state="attached")


### PR DESCRIPTION
## Summary
- implement fill modes on graph rendering and scale to start/end from data
- infer missing Start/End bounds on the server
- expose actual range and bucket size to client
- test default range and graph fill behaviour

## Testing
- `ruff check`
- `pyright`
- `pytest -q`