### PR TITLE
feat(ui): highlight chart paths on hover

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -134,6 +134,12 @@
     .col-group-header .links a {
       margin-left: 5px;
     }
+    #legend {
+      margin-bottom: 5px;
+    }
+    .legend-item.highlight {
+      background: #ddd;
+    }
     /* Column resizer removed */
   </style>
 </head>

--- a/scubaduck/static/js/timeseries_chart.js
+++ b/scubaduck/static/js/timeseries_chart.js
@@ -110,10 +110,22 @@ function showTimeSeries(data) {
     el.setAttribute('d', path.trim());
     el.setAttribute('fill', 'none');
     el.setAttribute('stroke', color);
+    el.setAttribute('stroke-width', '1');
     svg.appendChild(el);
     const item = document.createElement('div');
     item.textContent = key;
     item.style.color = color;
+    item.className = 'legend-item';
     legend.appendChild(item);
+
+    function highlight(on) {
+      el.setAttribute('stroke-width', on ? '3' : '1');
+      item.classList.toggle('highlight', on);
+    }
+
+    el.addEventListener('mouseenter', () => highlight(true));
+    el.addEventListener('mouseleave', () => highlight(false));
+    item.addEventListener('mouseenter', () => highlight(true));
+    item.addEventListener('mouseleave', () => highlight(false));
   });
 }

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -253,6 +253,30 @@ def test_timeseries_fill_options(page: Any, server_url: str) -> None:
     assert path_blank is not None and path_blank.count("M") > 1
 
 
+def test_timeseries_hover_highlight(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#graph_type", state="attached")
+    select_value(page, "#graph_type", "timeseries")
+    page.evaluate("window.lastResults = undefined")
+    page.click("text=Dive")
+    page.wait_for_function("window.lastResults !== undefined")
+    page.wait_for_selector("#chart path", state="attached")
+    path_el = page.query_selector("#chart path")
+    assert path_el
+    page.evaluate(
+        "el => el.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}))",
+        path_el,
+    )
+    width = page.evaluate(
+        "getComputedStyle(document.querySelector('#chart path')).strokeWidth"
+    )
+    assert "3" in width
+    color = page.evaluate(
+        "getComputedStyle(document.querySelector('#legend div')).backgroundColor"
+    )
+    assert "221, 221, 221" in color
+
+
 def test_help_and_alignment(page: Any, server_url: str) -> None:
     page.goto(server_url)
     page.wait_for_selector("#order_by option", state="attached")


### PR DESCRIPTION
## Summary
- make time series chart paths highlight on hover
- grey out legend entry for hovered path
- test hover highlighting behaviour

## Testing
- `ruff check`
- `pyright`
- `pytest -q`