### PR TITLE
feat(server): support multiple tables

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -138,7 +138,7 @@
   </style>
 </head>
 <body>
-  <div id="header">sample.csv - events <select id="graph_type"><option value="samples">Samples</option><option value="table">Table</option><option value="timeseries">Time Series</option></select></div>
+  <div id="header">sample.csv - <select id="table"></select> <select id="graph_type"><option value="samples">Samples</option><option value="table">Table</option><option value="timeseries">Time Series</option></select></div>
   <div id="content">
     <div id="sidebar">
       <div id="tabs">
@@ -459,118 +459,152 @@ orderDirBtn.addEventListener('click', () => {
 });
 updateOrderDirButton();
 graphTypeSel.addEventListener('change', updateDisplayTypeUI);
-fetch('/api/columns').then(r => r.json()).then(cols => {
-  const orderSelect = document.getElementById('order_by');
-  const xAxisSelect = document.getElementById('x_axis');
-  const groupsEl = document.getElementById('column_groups');
-  const groups = {
-    time: {name: 'Time', cols: [], ul: null},
-    integer: {name: 'Integers', cols: [], ul: null},
-    string: {name: 'Strings', cols: [], ul: null}
-  };
-  cols.forEach(c => {
-    const t = c.type.toUpperCase();
-    columnTypes[c.name] = c.type;
-    allColumns.push(c.name);
-    baseColumns.push(c.name);
-    let g = 'string';
-    if (t.includes('INT')) g = 'integer';
-    if (t.includes('TIMESTAMP')) {
-      g = 'time';
-      timeColumns.push(c.name);
-      baseTimeColumns.push(c.name);
-    }
-    if (g === 'string') {
-      stringColumns.push(c.name);
-      baseStringColumns.push(c.name);
-    } else {
-      integerColumns.push(c.name);
-      baseIntegerColumns.push(c.name);
-    }
-    groups[g].cols.push(c.name);
-    if (g !== 'string') {
+
+function loadColumns(table) {
+  return fetch('/api/columns?table=' + encodeURIComponent(table)).then(r => r.json()).then(cols => {
+    const orderSelect = document.getElementById('order_by');
+    const xAxisSelect = document.getElementById('x_axis');
+    const groupsEl = document.getElementById('column_groups');
+    orderSelect.innerHTML = '';
+    xAxisSelect.innerHTML = '';
+    groupsEl.innerHTML = '';
+    allColumns.length = 0;
+    stringColumns.length = 0;
+    integerColumns.length = 0;
+    timeColumns.length = 0;
+    baseColumns.length = 0;
+    baseStringColumns.length = 0;
+    baseIntegerColumns.length = 0;
+    baseTimeColumns.length = 0;
+    for (const k in columnTypes) delete columnTypes[k];
+    const groups = {
+      time: {name: 'Time', cols: [], ul: null},
+      integer: {name: 'Integers', cols: [], ul: null},
+      string: {name: 'Strings', cols: [], ul: null},
+    };
+    cols.forEach(c => {
+      const t = c.type.toUpperCase();
+      columnTypes[c.name] = c.type;
+      allColumns.push(c.name);
+      baseColumns.push(c.name);
+      let g = 'string';
+      if (t.includes('INT')) g = 'integer';
+      if (t.includes('TIMESTAMP')) {
+        g = 'time';
+        timeColumns.push(c.name);
+        baseTimeColumns.push(c.name);
+      }
+      if (g === 'string') {
+        stringColumns.push(c.name);
+        baseStringColumns.push(c.name);
+      } else {
+        integerColumns.push(c.name);
+        baseIntegerColumns.push(c.name);
+      }
+      groups[g].cols.push(c.name);
+      if (g !== 'string') {
+        const o = document.createElement('option');
+        o.value = c.name;
+        o.textContent = c.name;
+        orderSelect.appendChild(o);
+      }
+    });
+    timeColumns.forEach(name => {
       const o = document.createElement('option');
-      o.value = c.name;
-      o.textContent = c.name;
-      orderSelect.appendChild(o);
-    }
+      o.value = name;
+      o.textContent = name;
+      xAxisSelect.appendChild(o);
+    });
+    Object.keys(groups).forEach(key => {
+      const g = groups[key];
+      const div = document.createElement('div');
+      div.className = 'col-group';
+      const header = document.createElement('div');
+      header.className = 'col-group-header';
+      header.appendChild(document.createTextNode(g.name + ': '));
+      const links = document.createElement('span');
+      links.className = 'links';
+      const allBtn = document.createElement('a');
+      allBtn.href = '#';
+      allBtn.textContent = 'All';
+      const noneBtn = document.createElement('a');
+      noneBtn.href = '#';
+      noneBtn.textContent = 'None';
+      links.appendChild(allBtn);
+      links.appendChild(noneBtn);
+      header.appendChild(links);
+      div.appendChild(header);
+      const ul = document.createElement('ul');
+      g.ul = ul;
+      g.cols.forEach(name => {
+        const li = document.createElement('li');
+        const label = document.createElement('label');
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.value = name;
+        cb.checked = true;
+        cb.addEventListener('change', updateSelectedColumns);
+        label.appendChild(cb);
+        label.appendChild(document.createTextNode(' ' + name));
+        li.appendChild(label);
+        ul.appendChild(li);
+      });
+      allBtn.addEventListener('click', e => {
+        e.preventDefault();
+        ul.querySelectorAll('input').forEach(cb => (cb.checked = true));
+        updateSelectedColumns();
+      });
+      noneBtn.addEventListener('click', e => {
+        e.preventDefault();
+        ul.querySelectorAll('input').forEach(cb => (cb.checked = false));
+        updateSelectedColumns();
+      });
+      div.appendChild(ul);
+      groupsEl.appendChild(div);
+    });
+    document.getElementById('columns_all').addEventListener('click', e => {
+      e.preventDefault();
+      groupsEl.querySelectorAll('input').forEach(cb => (cb.checked = true));
+      updateSelectedColumns();
+    });
+    document.getElementById('columns_none').addEventListener('click', e => {
+      e.preventDefault();
+      groupsEl.querySelectorAll('input').forEach(cb => (cb.checked = false));
+      updateSelectedColumns();
+    });
+    updateSelectedColumns();
+    groupBy = document.getElementById('group_by').closest('.field');
+    initChipInput(groupBy, typed =>
+      allColumns.filter(c => c.toLowerCase().includes(typed.toLowerCase()))
+    );
+    initDropdown(orderSelect);
+    initDropdown(document.getElementById('aggregate'));
   });
-  timeColumns.forEach(name => {
+}
+
+let columnsInitialized = false;
+fetch('/api/tables').then(r => r.json()).then(tables => {
+  tables.forEach(t => {
     const o = document.createElement('option');
-    o.value = name;
-    o.textContent = name;
-    xAxisSelect.appendChild(o);
+    o.value = t;
+    o.textContent = t;
+    document.getElementById('table').appendChild(o);
   });
-  Object.keys(groups).forEach(key => {
-    const g = groups[key];
-    const div = document.createElement('div');
-    div.className = 'col-group';
-    const header = document.createElement('div');
-    header.className = 'col-group-header';
-    header.appendChild(document.createTextNode(g.name + ': '));
-    const links = document.createElement('span');
-    links.className = 'links';
-    const allBtn = document.createElement('a');
-    allBtn.href = '#';
-    allBtn.textContent = 'All';
-    const noneBtn = document.createElement('a');
-    noneBtn.href = '#';
-    noneBtn.textContent = 'None';
-    links.appendChild(allBtn);
-    links.appendChild(noneBtn);
-    header.appendChild(links);
-    div.appendChild(header);
-    const ul = document.createElement('ul');
-    g.ul = ul;
-    g.cols.forEach(name => {
-      const li = document.createElement('li');
-      const label = document.createElement('label');
-      const cb = document.createElement('input');
-      cb.type = 'checkbox';
-      cb.value = name;
-      cb.checked = true;
-      cb.addEventListener('change', updateSelectedColumns);
-      label.appendChild(cb);
-      label.appendChild(document.createTextNode(' ' + name));
-      li.appendChild(label);
-      ul.appendChild(li);
+  const table = parseSearch().table || tables[0];
+  document.getElementById('table').value = table;
+  loadColumns(table).then(() => {
+    updateDisplayTypeUI();
+    addFilter();
+    initFromUrl();
+    columnsInitialized = true;
+  });
+  document.getElementById('table').addEventListener('change', () => {
+    loadColumns(document.getElementById('table').value).then(() => {
+      if (columnsInitialized) {
+        applyParams(parseSearch());
+      }
     });
-    allBtn.addEventListener('click', e => {
-      e.preventDefault();
-      ul.querySelectorAll('input').forEach(cb => (cb.checked = true));
-      updateSelectedColumns();
-    });
-    noneBtn.addEventListener('click', e => {
-      e.preventDefault();
-      ul.querySelectorAll('input').forEach(cb => (cb.checked = false));
-      updateSelectedColumns();
-    });
-    div.appendChild(ul);
-    groupsEl.appendChild(div);
   });
-  document.getElementById('columns_all').addEventListener('click', e => {
-    e.preventDefault();
-    groupsEl.querySelectorAll('input').forEach(cb => (cb.checked = true));
-    updateSelectedColumns();
-  });
-  document.getElementById('columns_none').addEventListener('click', e => {
-    e.preventDefault();
-    groupsEl.querySelectorAll('input').forEach(cb => (cb.checked = false));
-    updateSelectedColumns();
-  });
-  updateSelectedColumns();
-  groupBy = document.getElementById('group_by').closest('.field');
-  initChipInput(groupBy, typed =>
-    allColumns.filter(c => c.toLowerCase().includes(typed.toLowerCase()))
-  );
-  initDropdown(orderSelect);
-  initDropdown(document.getElementById('aggregate'));
-  document.getElementById('limit').addEventListener('input', e => {
-    e.target.dataset.setByUser = '1';
-  });
-  updateDisplayTypeUI();
-  addFilter();
-  initFromUrl();
 });
 
 document.querySelectorAll('#tabs .tab').forEach(btn => {
@@ -843,6 +877,7 @@ function dive(push=true) {
 function collectParams() {
   updateSelectedColumns();
   const payload = {
+    table: document.getElementById('table').value,
     start: document.getElementById('start').value,
     end: document.getElementById('end').value,
     order_by: document.getElementById('order_by').value,
@@ -884,6 +919,7 @@ function collectParams() {
 
 function paramsToSearch(params) {
   const sp = new URLSearchParams();
+  if (params.table) sp.set('table', params.table);
   if (params.start) sp.set('start', params.start);
   if (params.end) sp.set('end', params.end);
   if (params.order_by) sp.set('order_by', params.order_by);
@@ -908,6 +944,7 @@ function paramsToSearch(params) {
 }
 
 function applyParams(params) {
+  if (params.table) document.getElementById('table').value = params.table;
   document.getElementById('start').value = params.start || '';
   document.getElementById('end').value = params.end || '';
   if (params.order_by) {
@@ -965,6 +1002,7 @@ function applyParams(params) {
 function parseSearch() {
   const sp = new URLSearchParams(window.location.search);
   const params = {};
+  if (sp.has('table')) params.table = sp.get('table');
   if (sp.has('start')) params.start = sp.get('start');
   if (sp.has('end')) params.end = sp.get('end');
   if (sp.has('order_by')) params.order_by = sp.get('order_by');

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,6 +12,7 @@ def test_basic_query() -> None:
     app = server.app
     client = app.test_client()
     payload = {
+        "table": "events",
         "start": "2024-01-01 00:00:00",
         "end": "2024-01-02 00:00:00",
         "order_by": "timestamp",
@@ -44,6 +45,7 @@ def test_filter_multi_token() -> None:
     app = server.app
     client = app.test_client()
     payload = {
+        "table": "events",
         "start": "2024-01-01 00:00:00",
         "end": "2024-01-02 03:00:00",
         "order_by": "timestamp",
@@ -67,6 +69,7 @@ def test_empty_filter_is_noop() -> None:
     app = server.app
     client = app.test_client()
     base_payload = {
+        "table": "events",
         "start": "2024-01-01 00:00:00",
         "end": "2024-01-03 00:00:00",
         "limit": 100,
@@ -93,6 +96,7 @@ def test_select_columns() -> None:
     app = server.app
     client = app.test_client()
     payload = {
+        "table": "events",
         "start": "2024-01-01 00:00:00",
         "end": "2024-01-03 00:00:00",
         "order_by": "timestamp",
@@ -151,6 +155,7 @@ def test_string_filter_ops() -> None:
 
 def _make_payload() -> dict[str, object]:
     return {
+        "table": "events",
         "start": "2024-01-01 00:00:00",
         "end": "2024-01-02 00:00:00",
         "order_by": "timestamp",
@@ -225,6 +230,7 @@ def test_group_by_table() -> None:
     app = server.app
     client = app.test_client()
     payload = {
+        "table": "events",
         "start": "2024-01-01 00:00:00",
         "end": "2024-01-03 00:00:00",
         "graph_type": "table",
@@ -260,6 +266,7 @@ def test_relative_time_query(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(server, "datetime", FixedDateTime)
 
     payload = {
+        "table": "events",
         "start": "-1 hour",
         "end": "now",
         "order_by": "timestamp",
@@ -280,6 +287,7 @@ def test_invalid_time_error() -> None:
     app = server.app
     client = app.test_client()
     payload = {
+        "table": "events",
         "start": "nonsense",
         "end": "now",
         "order_by": "timestamp",
@@ -299,6 +307,7 @@ def test_query_error_returns_sql_and_traceback() -> None:
     app = server.app
     client = app.test_client()
     payload = {
+        "table": "events",
         "start": "2024-01-01 00:00:00",
         "end": "2024-01-03 00:00:00",
         "columns": ["event"],
@@ -317,6 +326,7 @@ def test_table_unknown_column_error() -> None:
     app = server.app
     client = app.test_client()
     payload = {
+        "table": "events",
         "start": "2024-01-01 00:00:00",
         "end": "2024-01-03 00:00:00",
         "graph_type": "table",
@@ -339,6 +349,7 @@ def test_samples_view_rejects_group_by() -> None:
     app = server.app
     client = app.test_client()
     payload = {
+        "table": "events",
         "graph_type": "samples",
         "group_by": ["user"],
         "columns": ["timestamp"],
@@ -355,6 +366,7 @@ def test_table_avg_with_timestamp() -> None:
     app = server.app
     client = app.test_client()
     payload = {
+        "table": "events",
         "start": "2024-01-01 00:00:00",
         "end": "2024-01-03 00:00:00",
         "graph_type": "table",
@@ -381,6 +393,7 @@ def test_timeseries_basic() -> None:
     app = server.app
     client = app.test_client()
     payload = {
+        "table": "events",
         "start": "2024-01-01 00:00:00",
         "end": "2024-01-03 00:00:00",
         "graph_type": "timeseries",
@@ -403,6 +416,7 @@ def test_timeseries_orders_by_xaxis() -> None:
     app = server.app
     client = app.test_client()
     payload = {
+        "table": "events",
         "start": "2024-01-01 00:00:00",
         "end": "2024-01-03 00:00:00",
         "graph_type": "timeseries",
@@ -427,6 +441,7 @@ def test_timeseries_string_column_error() -> None:
     app = server.app
     client = app.test_client()
     payload = {
+        "table": "events",
         "start": "2024-01-01 00:00:00",
         "end": "2024-01-03 00:00:00",
         "graph_type": "timeseries",
@@ -447,6 +462,7 @@ def test_derived_column_basic() -> None:
     app = server.app
     client = app.test_client()
     payload = {
+        "table": "events",
         "start": "2024-01-01 00:00:00",
         "end": "2024-01-03 00:00:00",
         "limit": 10,
@@ -466,6 +482,7 @@ def test_timeseries_derived_column() -> None:
     app = server.app
     client = app.test_client()
     payload = {
+        "table": "events",
         "start": "2024-01-01 00:00:00",
         "end": "2024-01-03 00:00:00",
         "graph_type": "timeseries",
@@ -487,6 +504,7 @@ def test_default_start_end_returned() -> None:
     app = server.app
     client = app.test_client()
     payload = {
+        "table": "events",
         "order_by": "timestamp",
         "limit": 5,
         "columns": ["timestamp"],


### PR DESCRIPTION
## Summary
- add `table` parameter to queries
- attach SQLite databases via DuckDB's sqlite extension
- allow switching tables via `/api/tables`
- update frontend with table dropdown
- adjust tests for new behaviour
- fallback to manual sqlite import when sqlite extension unavailable

## Testing
- `ruff check scubaduck/server.py tests/test_server.py`
- `pyright`
- `pytest -q`
