### PR TITLE
fix(server): adjust timeseries limit by buckets

### DIFF
--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import os
 import sqlite3
 import traceback
+import math
 
 import duckdb
 from dateutil import parser as dtparser
@@ -506,6 +507,21 @@ def create_app(db_file: str | Path | None = None) -> Flask:
                 params.start if isinstance(params.start, str) else None,
                 params.end if isinstance(params.end, str) else None,
             )
+            if (
+                params.limit is not None
+                and params.start is not None
+                and params.end is not None
+            ):
+                try:
+                    start_dt = dtparser.parse(params.start)
+                    end_dt = dtparser.parse(params.end)
+                    buckets = math.ceil(
+                        (end_dt - start_dt).total_seconds() / bucket_size
+                    )
+                    if buckets > 1:
+                        params.limit *= buckets
+                except Exception:
+                    pass
 
         sql = build_query(params, column_types)
         try:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -438,6 +438,31 @@ def test_timeseries_orders_by_xaxis() -> None:
     assert timestamps == sorted(timestamps)
 
 
+def test_timeseries_limit_applies_to_series() -> None:
+    app = server.app
+    client = app.test_client()
+    payload = {
+        "table": "events",
+        "start": "2024-01-01 00:00:00",
+        "end": "2024-01-03 00:00:00",
+        "graph_type": "timeseries",
+        "limit": 1,
+        "order_by": "user",
+        "group_by": ["user"],
+        "aggregate": "Count",
+        "columns": ["value"],
+        "x_axis": "timestamp",
+        "granularity": "1 day",
+    }
+    rv = client.post(
+        "/api/query", data=json.dumps(payload), content_type="application/json"
+    )
+    data = rv.get_json()
+    assert rv.status_code == 200
+    assert len(data["rows"]) == 2
+    assert all(r[1] == "alice" for r in data["rows"])
+
+
 def test_timeseries_auto_and_fine_buckets() -> None:
     app = server.app
     client = app.test_client()


### PR DESCRIPTION
## Summary
- multiply timeseries SQL LIMIT by bucket count
- test limit behaviour for timeseries queries

## Testing
- `ruff format scubaduck/server.py tests/test_server.py`
- `ruff check .`
- `pyright`
- `pytest -q`
