### PR TITLE
fix: support large integers from sqlite

### DIFF
--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -51,7 +51,9 @@ def _normalize_sqlite_type(sql: str) -> str:
     if "(" in t:
         t = t.split("(", 1)[0]
     if "INT" in t:
-        return "INTEGER"
+        # SQLite only has a single INTEGER type which is always 64-bit.
+        # Use DuckDB's BIGINT to avoid overflow when values exceed INT32.
+        return "BIGINT"
     if any(key in t for key in ("CHAR", "CLOB", "TEXT")):
         return "VARCHAR"
     if "BLOB" in t:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -262,6 +262,60 @@ def test_sqlite_longvarchar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     assert data["rows"][0][1] == "https://a.com"
 
 
+def test_sqlite_bigint(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sqlite_file = tmp_path / "big.sqlite"
+    import sqlite3
+
+    conn = sqlite3.connect(sqlite_file)
+    conn.execute("CREATE TABLE events (timestamp TEXT, value INTEGER)")
+    big_value = 13385262862605259
+    conn.execute(
+        "INSERT INTO events VALUES ('2024-01-01 00:00:00', ?)",
+        (big_value,),
+    )
+    conn.commit()
+    conn.close()  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue]
+
+    from typing import Any
+
+    real_connect = duckdb.connect
+
+    def failing_connect(*args: Any, **kwargs: Any) -> Any:
+        real = real_connect(*args, **kwargs)
+
+        class Wrapper:
+            def __init__(self, con: duckdb.DuckDBPyConnection) -> None:
+                self.con = con
+                self._failed = False
+
+            def execute(self, sql: str, *a: Any, **kw: Any):
+                if not self._failed and sql == "LOAD sqlite":
+                    self._failed = True
+                    raise RuntimeError("fail")
+                return self.con.execute(sql, *a, **kw)
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self.con, name)
+
+        return Wrapper(real)
+
+    monkeypatch.setattr(server.duckdb, "connect", failing_connect)
+
+    app = server.create_app(sqlite_file)
+    client = app.test_client()
+    payload = {
+        "table": "events",
+        "order_by": "timestamp",
+        "columns": ["timestamp", "value"],
+    }
+    rv = client.post(
+        "/api/query", data=json.dumps(payload), content_type="application/json"
+    )
+    data = rv.get_json()
+    assert rv.status_code == 200
+    assert data["rows"][0][1] == big_value
+
+
 def test_envvar_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     csv_file = tmp_path / "custom.csv"
     csv_file.write_text("timestamp,event,value,user\n2024-01-01 00:00:00,login,5,bob\n")


### PR DESCRIPTION
## Summary
- map SQLite integer type to DuckDB BIGINT
- add regression test for BIGINT handling when SQLite extension fails

## Testing
- `ruff check scubaduck/server.py tests/test_server.py`
- `ruff format scubaduck/server.py tests/test_server.py`
- `pyright`
- `pytest -q`