### PR TITLE
fix(web): parse timestamps as UTC

### DIFF
--- a/scubaduck/static/js/timeseries_chart.js
+++ b/scubaduck/static/js/timeseries_chart.js
@@ -1,4 +1,10 @@
 function showTimeSeries(data) {
+  function parseTs(s) {
+    if (s.match(/GMT/) || s.endsWith('Z') || /\+\d{2}:?\d{2}$/.test(s)) {
+      return new Date(s).getTime();
+    }
+    return new Date(s + 'Z').getTime();
+  }
   const view = document.getElementById('view');
   if (data.rows.length === 0) {
     view.innerHTML = '<p id="empty-message">Empty data provided to table</p>';
@@ -18,11 +24,11 @@ function showTimeSeries(data) {
   const hasHits = document.getElementById('show_hits').checked ? 1 : 0;
   const fill = document.getElementById('fill').value;
   const bucketMs = (data.bucket_size || 3600) * 1000;
-  const start = data.start ? new Date(data.start).getTime() : null;
-  const end = data.end ? new Date(data.end).getTime() : null;
+  const start = data.start ? parseTs(data.start) : null;
+  const end = data.end ? parseTs(data.end) : null;
   const series = {};
   data.rows.forEach(r => {
-    const ts = new Date(r[0]).getTime();
+    const ts = parseTs(r[0]);
     const key = groups.map((_, i) => r[1 + i]).join(':') || 'all';
     const val = Number(r[1 + groups.length + hasHits]);
     if (!series[key]) series[key] = {};

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -277,6 +277,22 @@ def test_timeseries_hover_highlight(page: Any, server_url: str) -> None:
     assert "221, 221, 221" in color
 
 
+def test_timeseries_auto_timezone(browser: Any, server_url: str) -> None:
+    context = browser.new_context(timezone_id="America/New_York")
+    page = context.new_page()
+    page.goto(server_url)
+    page.wait_for_selector("#graph_type", state="attached")
+    select_value(page, "#graph_type", "timeseries")
+    page.evaluate("window.lastResults = undefined")
+    page.click("text=Dive")
+    page.wait_for_function("window.lastResults !== undefined")
+    path = page.get_attribute("#chart path", "d")
+    context.close()
+    assert path is not None
+    coords = [float(p.split(" ")[1]) for p in path.replace("M", "L").split("L")[1:]]
+    assert max(coords) > min(coords)
+
+
 def test_help_and_alignment(page: Any, server_url: str) -> None:
     page.goto(server_url)
     page.wait_for_selector("#order_by option", state="attached")


### PR DESCRIPTION
## Summary
- add regression test for timeseries with browser timezone
- parse timeseries timestamps as UTC to avoid timezone bugs

## Testing
- `ruff check`
- `pyright`
- `pytest -q`