### PR TITLE
feat(web): split timeseries legend pane

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -134,8 +134,20 @@
     .col-group-header .links a {
       margin-left: 5px;
     }
+    #ts-container {
+      display: flex;
+      height: 100%;
+    }
     #legend {
-      margin-bottom: 5px;
+      margin-bottom: 0;
+      margin-right: 10px;
+      width: 150px;
+      overflow-y: auto;
+      flex: 0 0 auto;
+    }
+    #chart-wrapper {
+      flex: 1;
+      overflow: auto;
     }
     .legend-item.highlight {
       background: #ddd;

--- a/scubaduck/static/js/timeseries_chart.js
+++ b/scubaduck/static/js/timeseries_chart.js
@@ -10,16 +10,16 @@ function showTimeSeries(data) {
     view.innerHTML = '<p id="empty-message">Empty data provided to table</p>';
     return;
   }
-  const width = 600;
   const height = 400;
   view.innerHTML =
-    '<div id="legend"></div><svg id="chart" width="' +
-    width +
-    '" height="' +
+    '<div id="ts-container"><div id="legend"></div><div id="chart-wrapper"><svg id="chart" height="' +
     height +
-    '"></svg>';
-  const svg = document.getElementById('chart');
+    '"></svg></div></div>';
   const legend = document.getElementById('legend');
+  const chartWrapper = document.getElementById('chart-wrapper');
+  const width = chartWrapper.clientWidth || 600;
+  const svg = document.getElementById('chart');
+  svg.setAttribute('width', width);
   const groups = groupBy.chips || [];
   const hasHits = document.getElementById('show_hits').checked ? 1 : 0;
   const fill = document.getElementById('fill').value;

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -277,6 +277,32 @@ def test_timeseries_hover_highlight(page: Any, server_url: str) -> None:
     assert "221, 221, 221" in color
 
 
+def test_timeseries_split_layout_resize(page: Any, server_url: str) -> None:
+    page.set_viewport_size({"width": 800, "height": 600})
+    page.goto(server_url)
+    page.wait_for_selector("#graph_type", state="attached")
+    select_value(page, "#graph_type", "timeseries")
+    page.evaluate("window.lastResults = undefined")
+    page.click("text=Dive")
+    page.wait_for_function("window.lastResults !== undefined")
+    page.wait_for_selector("#chart", state="attached")
+    legend_w1 = page.evaluate(
+        "document.querySelector('#legend').getBoundingClientRect().width"
+    )
+    chart_w1 = page.evaluate(
+        "document.querySelector('#chart-wrapper').getBoundingClientRect().width"
+    )
+    page.set_viewport_size({"width": 1000, "height": 600})
+    legend_w2 = page.evaluate(
+        "document.querySelector('#legend').getBoundingClientRect().width"
+    )
+    chart_w2 = page.evaluate(
+        "document.querySelector('#chart-wrapper').getBoundingClientRect().width"
+    )
+    assert legend_w1 == legend_w2
+    assert chart_w2 > chart_w1
+
+
 def test_timeseries_auto_timezone(browser: Any, server_url: str) -> None:
     context = browser.new_context(timezone_id="America/New_York")
     page = context.new_page()


### PR DESCRIPTION
## Summary
- split right pane into legend panel and chart container
- adjust timeseries chart JS for new layout
- ensure legend width fixed while chart grows
- test legend pane layout on resize

## Testing
- `ruff check`
- `pyright`
- `pytest -q`