### PR TITLE
fix(frontend): respect container padding in time series chart

### DIFF
--- a/scubaduck/static/js/timeseries_chart.js
+++ b/scubaduck/static/js/timeseries_chart.js
@@ -95,7 +95,11 @@ function showTimeSeries(data) {
   };
 
   function render() {
-    const width = svg.parentElement.clientWidth;
+    const style = getComputedStyle(svg.parentElement);
+    const width =
+      svg.parentElement.clientWidth -
+      parseFloat(style.paddingLeft) -
+      parseFloat(style.paddingRight);
     svg.setAttribute('width', width);
     svg.innerHTML = '';
     legend.innerHTML = '';

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1017,3 +1017,16 @@ def test_timeseries_resize(page: Any, server_url: str) -> None:
     after = chart_info()
     assert after["width"] > before["width"]
     assert after["last"] > before["last"]
+
+
+def test_timeseries_no_overflow(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#graph_type", state="attached")
+    select_value(page, "#graph_type", "timeseries")
+    page.evaluate("window.lastResults = undefined")
+    page.click("text=Dive")
+    page.wait_for_function("window.lastResults !== undefined")
+    overflow = page.evaluate(
+        "var v=document.getElementById('view'); v.scrollWidth > v.clientWidth"
+    )
+    assert not overflow


### PR DESCRIPTION
## Summary
- subtract parent padding when measuring chart width
- test to ensure time series chart doesn't overflow horizontally

## Testing
- `ruff check`
- `pyright`
- `pytest -q`