### PR TITLE
feat(web): split legend and chart panes

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -134,8 +134,17 @@
     .col-group-header .links a {
       margin-left: 5px;
     }
+    #ts-container {
+      display: flex;
+    }
     #legend {
-      margin-bottom: 5px;
+      width: 150px;
+      flex: 0 0 150px;
+      margin-right: 10px;
+      overflow-y: auto;
+    }
+    #chart-wrapper {
+      flex: 1;
     }
     .legend-item.highlight {
       background: #ddd;

--- a/scubaduck/static/js/timeseries_chart.js
+++ b/scubaduck/static/js/timeseries_chart.js
@@ -14,7 +14,10 @@ function showTimeSeries(data) {
     return;
   }
   const height = 400;
-  view.innerHTML = '<div id="legend"></div><svg id="chart" height="' + height + '"></svg>';
+  view.innerHTML =
+    '<div id="ts-container"><div id="legend"></div><div id="chart-wrapper"><svg id="chart" height="' +
+    height +
+    '"></svg></div></div>';
   const svg = document.getElementById('chart');
   const legend = document.getElementById('legend');
   const groups = groupBy.chips || [];

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1009,11 +1009,21 @@ def test_timeseries_resize(page: Any, server_url: str) -> None:
         )
 
     before = chart_info()
+    legend_width = page.evaluate(
+        "parseFloat(getComputedStyle(document.getElementById('legend')).width)"
+    )
+    assert page.evaluate(
+        "() => document.getElementById('legend').getBoundingClientRect().right <= document.getElementById('chart').getBoundingClientRect().left"
+    )
     page.evaluate("document.getElementById('sidebar').style.width='200px'")
     page.wait_for_function(
         "width => document.getElementById('chart').getAttribute('width') != width",
         arg=before["width"],
     )
     after = chart_info()
+    legend_width_after = page.evaluate(
+        "parseFloat(getComputedStyle(document.getElementById('legend')).width)"
+    )
     assert after["width"] > before["width"]
     assert after["last"] > before["last"]
+    assert legend_width_after == legend_width


### PR DESCRIPTION
## Summary
- split legend and chart into side-by-side panes
- keep legend width fixed while chart resizes
- test that layout works correctly

## Testing
- `ruff format scubaduck tests`
- `ruff check scubaduck tests`
- `pyright`
- `pytest -q`