### PR TITLE
feat(web): add crosshair selection for time series

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -277,6 +277,34 @@ def test_timeseries_hover_highlight(page: Any, server_url: str) -> None:
     assert "221, 221, 221" in color
 
 
+def test_timeseries_crosshair(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#graph_type", state="attached")
+    select_value(page, "#graph_type", "timeseries")
+    page.evaluate("window.lastResults = undefined")
+    page.click("text=Dive")
+    page.wait_for_function("window.lastResults !== undefined")
+    page.wait_for_selector("#chart path", state="attached")
+    page.eval_on_selector(
+        "#chart",
+        "el => { const r = el.getBoundingClientRect(); el.dispatchEvent(new MouseEvent('mousemove', {clientX: r.left + r.width/2, clientY: r.top + r.height/2, bubbles: true})); }",
+    )
+    line_display = page.evaluate(
+        "document.getElementById('crosshair_line').style.display"
+    )
+    assert line_display != "none"
+    count = page.eval_on_selector_all("#crosshair_dots circle", "els => els.length")
+    assert count > 0
+    page.eval_on_selector(
+        "#chart",
+        "el => el.dispatchEvent(new MouseEvent('mouseleave', {bubbles: true}))",
+    )
+    line_display = page.evaluate(
+        "document.getElementById('crosshair_line').style.display"
+    )
+    assert line_display == "none"
+
+
 def test_timeseries_auto_timezone(browser: Any, server_url: str) -> None:
     context = browser.new_context(timezone_id="America/New_York")
     page = context.new_page()


### PR DESCRIPTION
## Summary
- show crosshair when hovering time series chart
- choose nearest series using cursor position
- add Playwright test for crosshair behavior

## Testing
- `ruff format scubaduck tests`
- `ruff check scubaduck tests`
- `pyright`
- `pytest -q`