### PR TITLE
feat(web): add drill links to timeseries legend

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -163,6 +163,13 @@
     .legend-item.highlight {
       background: #ddd;
     }
+    #legend .drill-links h4 {
+      margin: 10px 0 4px 0;
+    }
+    #legend .drill-links a {
+      display: block;
+      margin-left: 8px;
+    }
     #chart text.tick-label {
       font-size: 10px;
       user-select: none;

--- a/scubaduck/static/js/timeseries_chart.js
+++ b/scubaduck/static/js/timeseries_chart.js
@@ -422,6 +422,39 @@ function showTimeSeries(data) {
     });
     svg.appendChild(axis);
     svg.appendChild(yAxis);
+
+    const helper = document.createElement('div');
+    helper.className = 'drill-links';
+    const heading = document.createElement('h4');
+    helper.appendChild(heading);
+    if ((groupBy.chips || []).length) {
+      heading.textContent = 'Drill up';
+      const link = document.createElement('a');
+      link.href = '#';
+      link.textContent = 'Aggregate';
+      link.addEventListener('click', e => {
+        e.preventDefault();
+        groupBy.chips = [];
+        groupBy.renderChips();
+        dive();
+      });
+      helper.appendChild(link);
+    } else {
+      heading.textContent = 'Group by';
+      (allColumns || []).forEach(col => {
+        const link = document.createElement('a');
+        link.href = '#';
+        link.textContent = col;
+        link.addEventListener('click', e => {
+          e.preventDefault();
+          groupBy.addChip(col);
+          groupBy.renderChips();
+          dive();
+        });
+        helper.appendChild(link);
+      });
+    }
+    legend.appendChild(helper);
   }
 
   render();

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1215,3 +1215,21 @@ def test_timeseries_legend_values(page: Any, server_url: str) -> None:
     )
     value = page.evaluate("document.querySelector('#legend .legend-value').textContent")
     assert value != ""
+
+
+def test_timeseries_group_links(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#graph_type", state="attached")
+    select_value(page, "#graph_type", "timeseries")
+    page.fill("#start", "2024-01-01 00:00:00")
+    page.fill("#end", "2024-01-02 03:00:00")
+    page.evaluate("window.lastResults = undefined")
+    page.click("text=Dive")
+    page.wait_for_function("window.lastResults !== undefined")
+    assert page.text_content("#legend .drill-links h4") == "Group by"
+    page.click("#legend .drill-links a:text('user')")
+    page.wait_for_function("window.lastResults !== undefined")
+    chips = page.evaluate("groupBy.chips")
+    assert chips == ["user"]
+    assert page.text_content("#legend .drill-links h4") == "Drill up"
+    assert page.is_visible("#legend .drill-links a:text('Aggregate')")


### PR DESCRIPTION
## Summary
- add drill links to time series legend for quick group-by changes
- add frontend test covering the drill links

## Testing
- `ruff check`
- `pyright`
- `pytest -q`