### PR TITLE
fix(sqlite): support large microsecond timestamps

### DIFF
--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -209,17 +209,21 @@ def _time_expr(col: str, column_types: Dict[str, str] | None, unit: str) -> str:
                 "HUGEINT",
             ]
         ):
-            divisor = {
-                "s": 1,
-                "ms": 1000,
-                "us": 1_000_000,
-                "ns": 1_000_000_000,
-            }.get(unit, 1)
-            if divisor == 1:
+            if unit == "ns":
                 expr = f"CAST({col} AS BIGINT)"
-            else:
-                expr = f"CAST({col} / {divisor} AS BIGINT)"
-            return f"TIMESTAMP 'epoch' + INTERVAL '1 second' * {expr}"
+                return f"make_timestamp_ns({expr})"
+
+            multiplier = {
+                "s": 1_000_000,
+                "ms": 1_000,
+                "us": 1,
+            }.get(unit, 1_000_000)
+            expr = (
+                f"CAST({col} * {multiplier} AS BIGINT)"
+                if multiplier != 1
+                else f"CAST({col} AS BIGINT)"
+            )
+            return f"make_timestamp({expr})"
     return col
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -383,6 +383,36 @@ def test_integer_time_unit_us_default_start_end(tmp_path: Path) -> None:
     assert len(data["rows"]) == 2
 
 
+def test_sqlite_integer_time_unit_us(tmp_path: Path) -> None:
+    sqlite_file = tmp_path / "events.sqlite"
+    import sqlite3
+
+    conn = sqlite3.connect(sqlite_file)
+    conn.execute("CREATE TABLE visits (visit_time INTEGER, event TEXT)")
+    big_ts = 13384551652000000
+    conn.execute("INSERT INTO visits VALUES (?, ?)", (big_ts, "foo"))
+    conn.commit()
+    conn.close()  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue]
+
+    app = server.create_app(sqlite_file)
+    client = app.test_client()
+    payload = {
+        "table": "visits",
+        "start": "2394-02-20 00:00:00",
+        "end": "2394-02-21 00:00:00",
+        "order_by": "visit_time",
+        "columns": ["visit_time", "event"],
+        "time_column": "visit_time",
+        "time_unit": "us",
+    }
+    rv = client.post(
+        "/api/query", data=json.dumps(payload), content_type="application/json"
+    )
+    data = rv.get_json()
+    assert rv.status_code == 200
+    assert len(data["rows"]) == 1
+
+
 def test_envvar_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     csv_file = tmp_path / "custom.csv"
     csv_file.write_text("timestamp,event,value,user\n2024-01-01 00:00:00,login,5,bob\n")


### PR DESCRIPTION
## Summary
- add regression test for microsecond timestamps in SQLite
- handle large integer-based timestamps using `make_timestamp` and `make_timestamp_ns`

## Testing
- `ruff format scubaduck/server.py tests/test_server.py`
- `ruff check scubaduck/server.py tests/test_server.py`
- `pyright`
- `pytest -q`