### PR TITLE
feat(web): add default x-axis option

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -531,6 +531,10 @@ function loadColumns(table) {
     const timeColumnSelect = document.getElementById('time_column');
     orderSelect.innerHTML = '';
     xAxisSelect.innerHTML = '';
+    const defOpt = document.createElement('option');
+    defOpt.value = '';
+    defOpt.textContent = '(default)';
+    xAxisSelect.appendChild(defOpt);
     timeColumnSelect.innerHTML = '';
     groupsEl.innerHTML = '';
     allColumns.length = 0;
@@ -598,6 +602,7 @@ function loadColumns(table) {
       o.textContent = name;
       timeColumnSelect.appendChild(o);
     });
+    xAxisSelect.value = '';
     defaultTimeColumn = guess || timeColumnOptions[0] || '';
     Object.keys(groups).forEach(key => {
       const g = groups[key];
@@ -1002,7 +1007,8 @@ function collectParams() {
     payload.show_hits = document.getElementById('show_hits').checked;
   }
   if (graphTypeSel.value === 'timeseries') {
-    payload.x_axis = document.getElementById('x_axis').value;
+    const xval = document.getElementById('x_axis').value;
+    if (xval) payload.x_axis = xval;
     payload.granularity = document.getElementById('granularity').value;
     payload.fill = document.getElementById('fill').value;
   }
@@ -1053,7 +1059,11 @@ function applyParams(params) {
   }
   graphTypeSel.value = params.graph_type || 'samples';
   updateDisplayTypeUI();
-  if (params.x_axis) document.getElementById('x_axis').value = params.x_axis;
+  if (params.x_axis) {
+    document.getElementById('x_axis').value = params.x_axis;
+  } else {
+    document.getElementById('x_axis').value = '';
+  }
   if (params.granularity) document.getElementById('granularity').value = params.granularity;
   if (params.fill) document.getElementById('fill').value = params.fill;
   if (params.group_by) {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -359,6 +359,30 @@ def test_integer_time_unit_ms(tmp_path: Path) -> None:
     assert len(data["rows"]) == 2
 
 
+def test_timeseries_default_xaxis_uses_time_column(tmp_path: Path) -> None:
+    csv_file = tmp_path / "events.csv"
+    csv_file.write_text("created,event\n1704067200000,login\n1704070800000,logout\n")
+    app = server.create_app(csv_file)
+    client = app.test_client()
+    payload = {
+        "table": "events",
+        "start": "2024-01-01 00:00:00",
+        "end": "2024-01-01 01:00:00",
+        "graph_type": "timeseries",
+        "granularity": "1 hour",
+        "columns": ["event"],
+        "aggregate": "Count",
+        "time_column": "created",
+        "time_unit": "ms",
+    }
+    rv = client.post(
+        "/api/query", data=json.dumps(payload), content_type="application/json"
+    )
+    data = rv.get_json()
+    assert rv.status_code == 200
+    assert len(data["rows"]) == 2
+
+
 def test_integer_time_unit_us_default_start_end(tmp_path: Path) -> None:
     csv_file = tmp_path / "events.csv"
     csv_file.write_text(

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -113,6 +113,16 @@ def test_time_unit_dropdown(page: Any, server_url: str) -> None:
     assert page.input_value("#time_unit") == "s"
 
 
+def test_x_axis_default_entry(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#graph_type", state="attached")
+    select_value(page, "#graph_type", "timeseries")
+    page.wait_for_selector("#x_axis option", state="attached")
+    options = page.locator("#x_axis option").all_inner_texts()
+    assert "(default)" in options
+    assert page.input_value("#x_axis") == ""
+
+
 def test_simple_filter(page: Any, server_url: str) -> None:
     page.goto(server_url)
     page.wait_for_selector("#order_by option", state="attached")


### PR DESCRIPTION
## Summary
- add default x-axis option that follows the time column
- skip sending x_axis when using the default
- test default x-axis option in the UI
- test timeseries queries with integer time column

## Testing
- `ruff check`
- `pyright`
- `pytest -q`