### PR TITLE
feat(web): prevent si suffix wrap

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -113,6 +113,7 @@
     #filters h4 { margin: 0 0 5px 0; }
     table { border-collapse: collapse; min-width: 100%; }
     th, td { border: 1px solid #ccc; padding: 4px; box-sizing: border-box; }
+    td.numeric { white-space: nowrap; }
     th { text-align: left; cursor: pointer; position: relative; }
     th.sorted { color: blue; }
     tr:nth-child(even) td { background: #f9f9f9; }
@@ -1214,6 +1215,9 @@ function renderTable(rows) {
         } else {
           td.textContent = isStringColumn(col) ? v : formatNumber(v);
         }
+      }
+      if (!isStringColumn(col) && !isTimeColumn(col)) {
+        td.classList.add('numeric');
       }
       td.style.textAlign = isStringColumn(col) ? 'left' : 'right';
       tr.appendChild(td);

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1062,6 +1062,14 @@ def test_format_number_function(page: Any, server_url: str) -> None:
     assert vals == ["815.21 K", "999.999", "0.000", "0"]
 
 
+def test_numeric_cell_nowrap(page: Any, server_url: str) -> None:
+    run_query(page, server_url, limit=10)
+    whitespace = page.evaluate(
+        "getComputedStyle(document.querySelector('#results td:nth-child(3)')).whiteSpace"
+    )
+    assert whitespace == "nowrap"
+
+
 def test_derived_column_query(page: Any, server_url: str) -> None:
     page.goto(server_url)
     page.wait_for_selector("#order_by option", state="attached")


### PR DESCRIPTION
## Summary
- forbid wrapping between number and SI unit suffix in numeric table cells
- test that numeric cells use nowrap CSS

## Testing
- `ruff format`
- `ruff check`
- `pyright`
- `pytest -q`