### PR TITLE
feat(web): store limit per chart type

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -367,6 +367,16 @@ let selectedColumns = [];
 let displayType = 'samples';
 let groupBy = {chips: [], addChip: () => {}, renderChips: () => {}};
 let defaultTimeColumn = '';
+const limitInput = document.getElementById('limit');
+const limitValues = {
+  samples: parseInt(limitInput.value, 10),
+  table: parseInt(limitInput.value, 10),
+  timeseries: 7
+};
+limitInput.addEventListener('input', () => {
+  limitValues[displayType] = parseInt(limitInput.value, 10);
+  limitInput.dataset.setByUser = '1';
+});
 
 function initDropdown(select) {
   const wrapper = document.createElement('div');
@@ -501,11 +511,12 @@ function updateDisplayTypeUI() {
       g.style.display = showTable || showTS ? 'none' : '';
     }
   });
+  limitValues[displayType] = parseInt(limitInput.value, 10);
+  if (showTS && limitValues.timeseries === undefined) {
+    limitValues.timeseries = 7;
+  }
+  limitInput.value = limitValues[graphTypeSel.value];
   if (showTS) {
-    const lim = document.getElementById('limit');
-    if (!lim.dataset.setByUser) {
-      lim.value = '7';
-    }
     document.querySelectorAll('#column_groups input').forEach(cb => {
       if (isTimeColumn(cb.value) || isStringColumn(cb.value)) {
         cb.checked = false;
@@ -1056,9 +1067,12 @@ function applyParams(params) {
   updateOrderDirButton();
   if (params.limit !== undefined && params.limit !== null) {
     document.getElementById('limit').value = params.limit;
+    limitValues[params.graph_type || 'samples'] = params.limit;
+    limitInput.dataset.setByUser = '1';
   }
   graphTypeSel.value = params.graph_type || 'samples';
   updateDisplayTypeUI();
+  limitInput.value = limitValues[graphTypeSel.value];
   if (params.x_axis) {
     document.getElementById('x_axis').value = params.x_axis;
   } else {

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -223,6 +223,16 @@ def test_graph_type_timeseries_fields(page: Any, server_url: str) -> None:
     assert page.is_visible("#fill_field")
 
 
+def test_limit_persists_per_chart_type(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#graph_type", state="attached")
+    assert page.input_value("#limit") == "100"
+    select_value(page, "#graph_type", "timeseries")
+    assert page.input_value("#limit") == "7"
+    select_value(page, "#graph_type", "samples")
+    assert page.input_value("#limit") == "100"
+
+
 def test_timeseries_default_query(page: Any, server_url: str) -> None:
     page.goto(server_url)
     page.wait_for_selector("#graph_type", state="attached")


### PR DESCRIPTION
## Summary
- keep separate limit value for Samples, Table and Time Series
- include the limit in URL application logic
- test limit resets when switching chart type

## Testing
- `ruff check`
- `pyright`
- `pytest -q`