### PR TITLE
fix(web): prevent date cell wrapping

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -114,6 +114,7 @@
     table { border-collapse: collapse; min-width: 100%; }
     th, td { border: 1px solid #ccc; padding: 4px; box-sizing: border-box; }
     td.numeric { white-space: nowrap; }
+    td.date { white-space: nowrap; }
     th { text-align: left; cursor: pointer; position: relative; }
     th.sorted { color: blue; }
     tr:nth-child(even) td { background: #f9f9f9; }
@@ -1257,6 +1258,7 @@ function renderTable(rows) {
           hour12: true,
           timeZoneName: 'short'
         });
+        td.classList.add('date');
       } else {
         if (col === 'Hits') {
           const pct = totalHits ? ((v / totalHits) * 100).toFixed(1) : '0';

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1142,6 +1142,14 @@ def test_numeric_cell_nowrap(page: Any, server_url: str) -> None:
     assert whitespace == "nowrap"
 
 
+def test_date_cell_nowrap(page: Any, server_url: str) -> None:
+    run_query(page, server_url, limit=10)
+    whitespace = page.evaluate(
+        "getComputedStyle(document.querySelector('#results td:nth-child(1)')).whiteSpace"
+    )
+    assert whitespace == "nowrap"
+
+
 def test_derived_column_query(page: Any, server_url: str) -> None:
     page.goto(server_url)
     page.wait_for_selector("#order_by option", state="attached")


### PR DESCRIPTION
## Summary
- make date cells nowrap in table
- test date nowrap behaviour

## Testing
- `ruff check tests/test_web.py`
- `pyright`
- `pytest -q`