### PR TITLE
fix(ui): avoid decimals for integer values

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -816,6 +816,7 @@ function formatNumber(val) {
     }
   }
   if (abs < 0.0005) return '0.000';
+  if (Number.isInteger(val)) return val.toString();
   return val.toFixed(3);
 }
 


### PR DESCRIPTION
## Summary
- avoid decimals for integer values in `formatNumber`

## Testing
- `ruff format`
- `ruff check`
- `pyright`
- `pytest -q`
