### PR TITLE
feat: allow disabling time column

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -539,12 +539,23 @@ function updateDisplayTypeUI() {
   updateSelectedColumns(newType);
   displayType = newType;
 }
+function updateTimeFieldVisibility() {
+  const show = document.getElementById('time_column').value !== '';
+  document.getElementById('start').closest('.field').style.display = show
+    ? 'flex'
+    : 'none';
+  document.getElementById('end').closest('.field').style.display = show
+    ? 'flex'
+    : 'none';
+}
 orderDirBtn.addEventListener('click', () => {
   orderDir = orderDir === 'ASC' ? 'DESC' : 'ASC';
   updateOrderDirButton();
 });
 updateOrderDirButton();
 graphTypeSel.addEventListener('change', updateDisplayTypeUI);
+document.getElementById('time_column').addEventListener('change', updateTimeFieldVisibility);
+updateTimeFieldVisibility();
 
 function loadColumns(table) {
   return fetch('/api/columns?table=' + encodeURIComponent(table)).then(r => r.json()).then(cols => {
@@ -559,6 +570,10 @@ function loadColumns(table) {
     defOpt.textContent = '(default)';
     xAxisSelect.appendChild(defOpt);
     timeColumnSelect.innerHTML = '';
+    const noneOpt = document.createElement('option');
+    noneOpt.value = '';
+    noneOpt.textContent = '(none)';
+    timeColumnSelect.appendChild(noneOpt);
     groupsEl.innerHTML = '';
     allColumns.length = 0;
     stringColumns.length = 0;
@@ -627,6 +642,7 @@ function loadColumns(table) {
     });
     xAxisSelect.value = '';
     defaultTimeColumn = guess || timeColumnOptions[0] || '';
+    updateTimeFieldVisibility();
     Object.keys(groups).forEach(key => {
       const g = groups[key];
       const div = document.createElement('div');
@@ -1078,6 +1094,7 @@ function paramsToSearch(params) {
 function applyParams(params) {
   if (params.table) document.getElementById('table').value = params.table;
   document.getElementById('time_column').value = params.time_column || defaultTimeColumn;
+  updateTimeFieldVisibility();
   if (params.time_unit) document.getElementById('time_unit').value = params.time_unit;
   document.getElementById('start').value = params.start || '';
   document.getElementById('end').value = params.end || '';

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -788,3 +788,20 @@ def test_default_start_end_returned() -> None:
     assert rv.status_code == 200
     assert data["start"] == "2024-01-01 00:00:00"
     assert data["end"] == "2024-01-02 03:00:00"
+
+
+def test_time_column_none_no_time_filter() -> None:
+    app = server.app
+    client = app.test_client()
+    payload = {
+        "table": "events",
+        "columns": ["timestamp", "event"],
+        "time_column": "",
+    }
+    rv = client.post(
+        "/api/query", data=json.dumps(payload), content_type="application/json"
+    )
+    data = rv.get_json()
+    assert rv.status_code == 200
+    assert "start" not in data and "end" not in data
+    assert len(data["rows"]) == 4

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -112,9 +112,24 @@ def test_time_column_dropdown(page: Any, server_url: str) -> None:
     page.goto(server_url)
     page.wait_for_selector("#time_column option", state="attached")
     options = page.locator("#time_column option").all_inner_texts()
+    assert "(none)" in options
     assert "timestamp" in options
     assert "value" in options
     assert page.input_value("#time_column") == "timestamp"
+
+
+def test_time_column_none_hides_range(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#time_column option", state="attached")
+    select_value(page, "#time_column", "")
+    assert page.is_hidden("#start")
+    assert page.is_hidden("#end")
+    page.evaluate("window.lastResults = undefined")
+    page.click("text=Dive")
+    page.wait_for_function("window.lastResults !== undefined")
+    data = page.evaluate("window.lastResults")
+    assert len(data["rows"]) == 4
+    assert "start" not in data and "end" not in data
 
 
 def test_time_unit_dropdown(page: Any, server_url: str) -> None:


### PR DESCRIPTION
## Summary
- allow `time_column` to be empty on the backend
- hide date range inputs when time column is unset
- add '(none)' option to the time column dropdown
- test no time column behaviour on server and web

## Testing
- `ruff format scubaduck/server.py tests/test_web.py tests/test_server.py`
- `ruff check scubaduck/server.py tests/test_web.py tests/test_server.py`
- `pyright`
- `pytest -q`