### PR TITLE
feat(web): show selected column count

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -194,7 +194,7 @@
     <div id="sidebar">
       <div id="tabs">
         <button class="tab active" data-tab="settings">View Settings</button>
-        <button class="tab" data-tab="columns">Columns</button>
+        <button id="columns_tab" class="tab" data-tab="columns">Columns</button>
         <button id="dive" onclick="dive()">Dive</button>
       </div>
       <div id="settings" class="tab-content active">
@@ -747,11 +747,19 @@ document.querySelectorAll('.rel-dropdown div').forEach(opt => {
     opt.parentElement.style.display = 'none';
   });
 });
+
 document.addEventListener('click', e => {
   document.querySelectorAll('.rel-dropdown').forEach(dd => {
     if (!dd.parentElement.contains(e.target)) dd.style.display = 'none';
   });
 });
+
+function updateColumnsTabCount() {
+  const baseCount = document.querySelectorAll('#column_groups input:checked').length;
+  const derivedCount = document.querySelectorAll('#derived_list .derived .d-use:checked').length;
+  const btn = document.getElementById('columns_tab');
+  if (btn) btn.textContent = `Columns (${baseCount + derivedCount})`;
+}
 
 function updateSelectedColumns(type = graphTypeSel.value) {
   const base = allColumns.filter(name => {
@@ -776,6 +784,7 @@ function updateSelectedColumns(type = graphTypeSel.value) {
     });
   }
   columnValues[type] = selectedColumns.slice();
+  updateColumnsTabCount();
 }
 
 function isStringColumn(name) {

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -655,6 +655,18 @@ def test_column_group_links_float_right(page: Any, server_url: str) -> None:
     assert float_val == "right"
 
 
+def test_columns_tab_selected_count(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#order_by option", state="attached")
+    count_text = page.text_content("#columns_tab")
+    assert count_text is not None and "(4)" in count_text
+    page.click("text=Columns")
+    page.wait_for_selector("#column_groups input", state="attached")
+    page.uncheck("#column_groups input[value='value']")
+    count_text = page.text_content("#columns_tab")
+    assert count_text is not None and "(3)" in count_text
+
+
 def test_chip_dropdown_navigation(page: Any, server_url: str) -> None:
     page.goto(server_url)
     page.wait_for_selector("#order_by option", state="attached")


### PR DESCRIPTION
## Summary
- display how many columns are currently selected in the Columns tab
- test the new tab label behaviour

## Testing
- `ruff check`
- `pyright`
- `pytest -q`