### PR TITLE
feat(web): make table selector searchable

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -700,22 +700,24 @@ function loadColumns(table) {
 
 let columnsInitialized = false;
 fetch('/api/tables').then(r => r.json()).then(tables => {
+  const tableSel = document.getElementById('table');
   tables.forEach(t => {
     const o = document.createElement('option');
     o.value = t;
     o.textContent = t;
-    document.getElementById('table').appendChild(o);
+    tableSel.appendChild(o);
   });
+  initDropdown(tableSel);
   const table = parseSearch().table || tables[0];
-  document.getElementById('table').value = table;
+  tableSel.value = table;
   loadColumns(table).then(() => {
     updateDisplayTypeUI();
     addFilter();
     initFromUrl();
     columnsInitialized = true;
   });
-  document.getElementById('table').addEventListener('change', () => {
-    loadColumns(document.getElementById('table').value).then(() => {
+  tableSel.addEventListener('change', () => {
+    loadColumns(tableSel.value).then(() => {
       if (columnsInitialized) {
         applyParams(parseSearch());
       }

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -125,6 +125,18 @@ def test_time_unit_dropdown(page: Any, server_url: str) -> None:
     assert page.input_value("#time_unit") == "s"
 
 
+def test_table_selector_dropdown(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#table option", state="attached")
+    disp = page.query_selector("#table + .dropdown-display")
+    assert disp
+    assert (
+        page.evaluate("getComputedStyle(document.querySelector('#table')).display")
+        == "none"
+    )
+    assert page.query_selector("#table + .dropdown-display + .dropdown-menu input")
+
+
 def test_x_axis_default_entry(page: Any, server_url: str) -> None:
     page.goto(server_url)
     page.wait_for_selector("#graph_type", state="attached")


### PR DESCRIPTION
## Summary
- make table selector dropdown searchable by using the custom dropdown UI
- test that the table selector uses a hidden select and dropdown display

## Testing
- `ruff check`
- `pyright`
- `pytest -q`