### PR TITLE
fix(web): prevent duplicate dropdown

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -386,6 +386,17 @@ limitInput.addEventListener('input', () => {
 });
 
 function initDropdown(select) {
+  // Avoid creating duplicate wrappers if this dropdown was already initialised.
+  if (select.dataset.dropdownInit) {
+    const disp = select.parentElement?.querySelector('.dropdown-display');
+    if (disp) {
+      const opt = select.options[select.selectedIndex];
+      disp.textContent = opt ? opt.textContent : '';
+    }
+    return;
+  }
+  select.dataset.dropdownInit = '1';
+
   const wrapper = document.createElement('div');
   wrapper.className = 'dropdown';
   if (select.classList.contains('f-col')) {


### PR DESCRIPTION
## Summary
- avoid creating duplicate dropdown wrappers when reloading columns

## Testing
- `ruff format`
- `ruff check`
- `pyright`
- `pytest -q`
