### PR TITLE
feat(server): add TEST database option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,6 @@ flask --app scubaduck.server run --debug
 
 By default the server loads `sample.csv`. Set the `SCUBADUCK_DB` environment
 variable to point at a different database file (CSV, SQLite or DuckDB) if you
-want to use another dataset. If the file does not exist, the server will raise
-a `FileNotFoundError` during startup.
+want to use another dataset. The special value `TEST` starts the server with a
+small in-memory SQLite dataset used by the automated tests. If the file does
+not exist, the server will raise a `FileNotFoundError` during startup.

--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -73,6 +73,20 @@ def _load_database(path: Path) -> duckdb.DuckDBPyConnection:
     return con
 
 
+def _create_test_database() -> duckdb.DuckDBPyConnection:
+    """Return a DuckDB connection with a small multi-table dataset."""
+    con = duckdb.connect()
+    con.execute(
+        "CREATE TABLE events (id INTEGER PRIMARY KEY, ts TEXT, val REAL, name TEXT, flag BOOLEAN)"
+    )
+    con.execute("INSERT INTO events VALUES (1, '2024-01-01 00:00:00', 1.5, 'alice', 1)")
+    con.execute("INSERT INTO events VALUES (2, '2024-01-01 01:00:00', 2.0, 'bob', 0)")
+    con.execute('CREATE TABLE extra (ts TEXT, "desc" TEXT, num INTEGER)')
+    con.execute("INSERT INTO extra VALUES ('2024-01-01 00:00:00', 'x', 1)")
+    con.execute("INSERT INTO extra VALUES ('2024-01-01 01:00:00', 'y', 2)")
+    return con
+
+
 _REL_RE = re.compile(
     r"([+-]?\d+(?:\.\d*)?)\s*(hour|hours|day|days|week|weeks|fortnight|fortnights)",
     re.IGNORECASE,
@@ -320,8 +334,11 @@ def create_app(db_file: str | Path | None = None) -> Flask:
         env_db = os.environ.get("SCUBADUCK_DB")
         if env_db:
             db_file = env_db
-    db_path = Path(db_file or Path(__file__).with_name("sample.csv")).resolve()
-    con = _load_database(db_path)
+    if isinstance(db_file, str) and db_file.upper() == "TEST":
+        con = _create_test_database()
+    else:
+        db_path = Path(db_file or Path(__file__).with_name("sample.csv")).resolve()
+        con = _load_database(db_path)
     tables = [r[0] for r in con.execute("SHOW TABLES").fetchall()]
     if not tables:
         raise ValueError("No tables found in database")

--- a/tests/test_multi_table_web.py
+++ b/tests/test_multi_table_web.py
@@ -1,6 +1,4 @@
-import sqlite3
 import threading
-from pathlib import Path
 from collections.abc import Iterator
 from typing import Any
 
@@ -12,23 +10,8 @@ from tests.test_web import select_value
 
 
 @pytest.fixture()
-def multi_table_server_url(tmp_path: Path) -> Iterator[str]:
-    db_path = tmp_path / "complex.sqlite"
-    conn = sqlite3.connect(db_path)
-    conn.execute(
-        "CREATE TABLE events (id INTEGER PRIMARY KEY, ts TEXT, val REAL, name TEXT, flag BOOLEAN)"
-    )
-    conn.execute(
-        "INSERT INTO events VALUES (1, '2024-01-01 00:00:00', 1.5, 'alice', 1)"
-    )
-    conn.execute("INSERT INTO events VALUES (2, '2024-01-01 01:00:00', 2.0, 'bob', 0)")
-    conn.execute("CREATE TABLE extra (ts TEXT, desc TEXT, num INTEGER)")
-    conn.execute("INSERT INTO extra VALUES ('2024-01-01 00:00:00', 'x', 1)")
-    conn.execute("INSERT INTO extra VALUES ('2024-01-01 01:00:00', 'y', 2)")
-    conn.commit()
-    conn.close()
-
-    app = create_app(db_path)
+def multi_table_server_url() -> Iterator[str]:
+    app = create_app("TEST")
     httpd = make_server("127.0.0.1", 0, app)
     port = httpd.server_port
     thread = threading.Thread(target=httpd.serve_forever)


### PR DESCRIPTION
## Summary
- rename `test_table_dropdown.py` to `test_multi_table_web.py`
- create helper for test database
- allow special `TEST` database selection in `create_app`
- document TEST database option in README

## Testing
- `ruff format tests/test_multi_table_web.py scubaduck/server.py`
- `ruff check scubaduck/server.py tests/test_multi_table_web.py`
- `pyright`
- `pytest -q`