### PR TITLE
test(web): verify dropdown shows selected table

### DIFF
--- a/scubaduck/static/index.html
+++ b/scubaduck/static/index.html
@@ -750,6 +750,7 @@ let columnsInitialized = false;
     if (disp) disp.style.minWidth = maxWidth + 30 + 'px';
     const table = parseSearch().table || tables[0];
     tableSel.value = table;
+    tableSel.dispatchEvent(new Event('change'));
   loadColumns(table).then(() => {
     updateDisplayTypeUI();
     addFilter();

--- a/tests/test_multi_table_web.py
+++ b/tests/test_multi_table_web.py
@@ -34,3 +34,19 @@ def test_table_param_updates_on_dive(page: Any, multi_table_server_url: str) -> 
         "new URLSearchParams(window.location.search).get('table')"
     )
     assert table_param == "extra"
+
+
+def test_table_dropdown_persists_on_refresh(
+    page: Any, multi_table_server_url: str
+) -> None:
+    page.goto(multi_table_server_url + "?table=events")
+    page.wait_for_selector("#table option", state="attached")
+    select_value(page, "#table", "extra")
+    page.evaluate("window.lastResults = undefined")
+    page.click("text=Dive")
+    page.wait_for_function("window.lastResults !== undefined")
+    page.reload()
+    page.wait_for_selector("#table option", state="attached")
+    assert page.input_value("#table") == "extra"
+    disp = page.text_content("#table + .dropdown-display")
+    assert disp is not None and disp.strip() == "extra"


### PR DESCRIPTION
## Summary
- address feedback for table dropdown test
- ensure dropdown display text matches selected table on refresh
- update front-end to dispatch change event when table param set

## Testing
- `ruff check`
- `pyright`
- `pytest -q`
