### PR TITLE
fix(web): refine time column guessing

### DIFF
--- a/scubaduck/static/js/time_column.js
+++ b/scubaduck/static/js/time_column.js
@@ -1,19 +1,19 @@
 // Helper for choosing a default time column based on column names/types
 function guessTimeColumn(columns) {
   const heur = ['timestamp','created','created_at','event_time','time','date','occurred','happened','logged'];
-  let guess = null;
-  let first = null;
+  let heurGuess = null;
+  let timestamp = null;
   columns.forEach(c => {
     const t = (c.type || '').toUpperCase();
     const isNumeric = t.includes('INT') || t.includes('DECIMAL') || t.includes('NUMERIC') ||
                       t.includes('REAL') || t.includes('DOUBLE') || t.includes('FLOAT') || t.includes('HUGEINT');
     const isTimeType = t.includes('TIMESTAMP') || t.includes('DATE') || t.includes('TIME');
-    if (isNumeric || isTimeType) {
-      if (!first) first = c.name;
-      if (!guess && heur.some(h => c.name.toLowerCase().includes(h))) {
-        guess = c.name;
-      }
+    if (heur.some(h => c.name.toLowerCase().includes(h)) && (isTimeType || isNumeric)) {
+      if (!heurGuess) heurGuess = c.name;
+    }
+    if (!timestamp && isTimeType) {
+      timestamp = c.name;
     }
   });
-  return guess || first || null;
+  return heurGuess || timestamp || null;
 }


### PR DESCRIPTION
## Summary
- update `guessTimeColumn` heuristic to avoid numeric columns without a matching name

## Testing
- `ruff format`
- `ruff check`
- `pyright` *(fails: no network access)*
- `pytest -q`