### PR TITLE
fix(web): hide time unit when no time column

### DIFF
--- a/scubaduck/static/js/view_settings.js
+++ b/scubaduck/static/js/view_settings.js
@@ -182,6 +182,7 @@ function updateTimeFieldVisibility() {
   document.getElementById('end').closest('.field').style.display = show
     ? 'flex'
     : 'none';
+  document.getElementById('time_unit').style.display = show ? '' : 'none';
 }
 orderDirBtn.addEventListener('click', () => {
   orderDir = orderDir === 'ASC' ? 'DESC' : 'ASC';

--- a/tests/test_web_basics.py
+++ b/tests/test_web_basics.py
@@ -82,6 +82,13 @@ def test_time_unit_dropdown(page: Any, server_url: str) -> None:
     assert page.input_value("#time_unit") == "s"
 
 
+def test_time_unit_hidden_when_no_time_column(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#time_column option", state="attached")
+    select_value(page, "#time_column", "")
+    assert page.is_hidden("#time_unit")
+
+
 def test_table_selector_dropdown(page: Any, server_url: str) -> None:
     page.goto(server_url)
     page.wait_for_selector("#table option", state="attached")


### PR DESCRIPTION
## Summary
- hide time unit dropdown when no time column selected
- test that time unit select disappears if time column set to none

## Testing
- `ruff format tests/test_web_basics.py`
- `ruff check`
- `pyright`
- `pytest -k time_unit_hidden_when_no_time_column -q`