### PR TITLE
feat(web): show order column when used

### DIFF
--- a/scubaduck/static/js/view_settings.js
+++ b/scubaduck/static/js/view_settings.js
@@ -451,6 +451,10 @@ function updateSelectedColumns(type = graphTypeSel.value) {
     });
   }
   columnValues[type] = selectedColumns.slice();
+  const orderCol = document.getElementById('order_by').value;
+  if (orderCol && !selectedColumns.includes(orderCol)) {
+    selectedColumns.push(orderCol);
+  }
   updateColumnsTabCount();
 }
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,25 @@
+from typing import Any
+from tests.web_utils import select_value
+
+
+def test_order_by_implicit_column(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#order_by option", state="attached")
+    page.click("text=Columns")
+    page.wait_for_selector("#column_groups input", state="attached")
+    page.uncheck("#column_groups input[value='timestamp']")
+    page.click("text=View Settings")
+    page.fill("#start", "2024-01-01 00:00:00")
+    page.fill("#end", "2024-01-02 00:00:00")
+    select_value(page, "#order_by", "timestamp")
+    page.fill("#limit", "10")
+    page.evaluate("window.lastResults = undefined")
+    page.click("text=Dive")
+    page.wait_for_function("window.lastResults !== undefined")
+    data = page.evaluate("window.lastResults")
+    headers = page.locator("#results th").all_inner_texts()
+    assert "timestamp" in headers
+    assert len(data["rows"][0]) == 4
+    page.click("text=Columns")
+    page.wait_for_selector("#column_groups input", state="attached")
+    assert not page.is_checked("#column_groups input[value='timestamp']")


### PR DESCRIPTION
## Summary
- implicitly include order column when not selected
- test that ordering by an unselected column still shows it

## Testing
- `ruff check`
- `pyright`
- `pytest -q`