### PR TITLE
fix(server): ignore order_by without selected column

### DIFF
--- a/tests/test_server_basic.py
+++ b/tests/test_server_basic.py
@@ -148,3 +148,19 @@ def test_string_filter_ops() -> None:
         "/api/query", data=json.dumps(not_empty), content_type="application/json"
     )
     assert len(rv.get_json()["rows"]) == 4
+
+
+def test_order_by_ignored_when_not_selected() -> None:
+    app = server.app
+    client = app.test_client()
+    payload = {
+        "table": "events",
+        "order_by": "value",
+        "columns": ["timestamp"],
+    }
+    rv = client.post(
+        "/api/query", data=json.dumps(payload), content_type="application/json"
+    )
+    data = rv.get_json()
+    assert rv.status_code == 200
+    assert "ORDER BY" not in data["sql"]


### PR DESCRIPTION
## Summary
- ignore order_by when its column is not in selected columns
- test that order_by is omitted if not selected

## Testing
- `ruff format tests/test_server_basic.py scubaduck/server.py`
- `ruff check tests/test_server_basic.py scubaduck/server.py`
- `pyright scubaduck/server.py tests/test_server_basic.py`
- `pytest -q`