### PR TITLE
fix: left align table headers

### DIFF
--- a/scubaduck/static/js/table_view.js
+++ b/scubaduck/static/js/table_view.js
@@ -32,7 +32,7 @@ function renderTable(rows) {
       th.classList.add("sorted");
       th.textContent = label + (sortState.dir === "desc" ? " \u25BC" : " \u25B2");
     }
-    if (!isStringColumn(col)) th.style.textAlign = "right";
+    th.style.textAlign = "left";
     header.appendChild(th);
   });
   table.appendChild(header);

--- a/tests/test_web_table.py
+++ b/tests/test_web_table.py
@@ -19,7 +19,7 @@ def test_table_sorting(page: Any, server_url: str) -> None:
     align = page.evaluate(
         "getComputedStyle(document.querySelector('#results th')).textAlign"
     )
-    assert align == "right"
+    assert align == "left"
 
     header = page.locator("#results th").nth(3)
 


### PR DESCRIPTION
## Summary
- always left align table headers
- update tests for left aligned headers

## Testing
- `ruff format`
- `ruff check`
- `pyright`
- `pytest -q`
