### PR TITLE
fix(server): allow avg on bool columns

### DIFF
--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -544,7 +544,7 @@ def create_app(db_file: str | Path | None = None) -> Flask:
                     if c not in column_types:
                         continue
                     ctype = column_types.get(c, "").upper()
-                    is_numeric = any(
+                    is_numeric = "BOOL" in ctype or any(
                         t in ctype
                         for t in [
                             "INT",


### PR DESCRIPTION
## Summary
- allow boolean columns to pass numeric aggregate validation
- test avg aggregation on boolean column with group by

## Testing
- `ruff check scubaduck/server.py tests/test_server_db_types.py`
- `pyright scubaduck/server.py tests/test_server_db_types.py`
- `pytest -q`