### PR TITLE
fix(table): hide unused columns on count

### DIFF
--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -248,14 +248,19 @@ def build_query(params: QueryParams, column_types: Dict[str, str] | None = None)
             return f"{agg}({expr})"
 
         if agg == "count":
-            select_parts.append("count(*) AS Count")
+            if params.graph_type == "table" and params.show_hits:
+                select_parts.insert(len(group_cols), "count(*) AS Hits")
+            else:
+                select_parts.append("count(*) AS Count")
+                if params.show_hits:
+                    select_parts.insert(len(group_cols), "count(*) AS Hits")
         else:
             for col in params.columns:
                 if col in group_cols:
                     continue
                 select_parts.append(f"{agg_expr(col)} AS {_quote(col)}")
-        if params.show_hits:
-            select_parts.insert(len(group_cols), "count(*) AS Hits")
+            if params.show_hits:
+                select_parts.insert(len(group_cols), "count(*) AS Hits")
     else:
         select_parts.extend(_quote(c) for c in params.columns)
 

--- a/scubaduck/static/js/view_settings.js
+++ b/scubaduck/static/js/view_settings.js
@@ -435,22 +435,32 @@ function updateSelectedColumns(type = graphTypeSel.value) {
     if (type === 'table' && isStringColumn(name)) return false;
     return true;
   });
+  let storeCols;
   if (type === 'table' || type === 'timeseries') {
-    selectedColumns = groupBy.chips.slice();
-    if (document.getElementById('show_hits').checked) selectedColumns.push('Hits');
+    storeCols = groupBy.chips.slice();
+    if (document.getElementById('show_hits').checked) storeCols.push('Hits');
     base.forEach(c => {
-      if (!selectedColumns.includes(c)) selectedColumns.push(c);
+      if (!storeCols.includes(c)) storeCols.push(c);
     });
     derivedColumns.forEach(dc => {
-      if (dc.include && !selectedColumns.includes(dc.name)) selectedColumns.push(dc.name);
+      if (dc.include && !storeCols.includes(dc.name)) storeCols.push(dc.name);
     });
+    selectedColumns = storeCols.slice();
+    if (type === 'table') {
+      const agg = document.getElementById('aggregate').value.toLowerCase();
+      if (agg === 'count') {
+        selectedColumns = groupBy.chips.slice();
+        if (document.getElementById('show_hits').checked) selectedColumns.push('Hits');
+      }
+    }
   } else {
     selectedColumns = base.slice();
     derivedColumns.forEach(dc => {
       if (dc.include) selectedColumns.push(dc.name);
     });
+    storeCols = selectedColumns.slice();
   }
-  columnValues[type] = selectedColumns.slice();
+  columnValues[type] = storeCols.slice();
   updateColumnsTabCount();
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,25 @@ from collections.abc import Iterator
 import pytest
 from werkzeug.serving import make_server
 
-from scubaduck.server import app
+from scubaduck.server import app, create_app
 
 
 @pytest.fixture()
 def server_url() -> Iterator[str]:
+    httpd = make_server("127.0.0.1", 0, app)
+    port = httpd.server_port
+    thread = threading.Thread(target=httpd.serve_forever)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        httpd.shutdown()
+        thread.join()
+
+
+@pytest.fixture()
+def multi_table_server_url() -> Iterator[str]:
+    app = create_app("TEST")
     httpd = make_server("127.0.0.1", 0, app)
     port = httpd.server_port
     thread = threading.Thread(target=httpd.serve_forever)


### PR DESCRIPTION
## Summary
- hide Count column when Hits already shown in table queries
- keep column selections when count aggregate is used
- add test for column headings with count aggregate
- expose multi_table_server_url fixture for tests

## Testing
- `ruff check`
- `pyright`
- `pytest -q`