### PR TITLE
feat(web): hide agg columns when count

### DIFF
--- a/scubaduck/static/js/view_settings.js
+++ b/scubaduck/static/js/view_settings.js
@@ -439,12 +439,15 @@ function updateSelectedColumns(type = graphTypeSel.value) {
   if (type === 'table' || type === 'timeseries') {
     selectedColumns = groupBy.chips.slice();
     if (document.getElementById('show_hits').checked) selectedColumns.push('Hits');
-    base.forEach(c => {
-      if (!selectedColumns.includes(c)) selectedColumns.push(c);
-    });
-    derivedColumns.forEach(dc => {
-      if (dc.include && !selectedColumns.includes(dc.name)) selectedColumns.push(dc.name);
-    });
+    const agg = document.getElementById('aggregate').value.toLowerCase();
+    if (!(type === 'table' && agg === 'count')) {
+      base.forEach(c => {
+        if (!selectedColumns.includes(c)) selectedColumns.push(c);
+      });
+      derivedColumns.forEach(dc => {
+        if (dc.include && !selectedColumns.includes(dc.name)) selectedColumns.push(dc.name);
+      });
+    }
   } else {
     selectedColumns = base.slice();
     derivedColumns.forEach(dc => {


### PR DESCRIPTION
## Summary
- avoid showing aggregate columns in table view when aggregate is `Count`
- spin up a test dataset server for web tests
- check that count table only shows group-by and Hits columns

## Testing
- `ruff check scubaduck tests`
- `pyright`
- `pytest -q`