### PR TITLE
fix(server): align count headers with data

### DIFF
--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -296,15 +296,20 @@ def build_query(params: QueryParams, column_types: Dict[str, str] | None = None)
             return f"{agg}({expr})"
 
         if agg == "count":
-            select_parts.append("count(*) AS Count")
-            selected_for_order.add("Count")
+            if params.graph_type == "table":
+                col_name = "Hits" if params.show_hits else "Count"
+                select_parts.append(f"count(*) AS {col_name}")
+                selected_for_order.add(col_name)
+            else:
+                select_parts.append("count(*) AS Count")
+                selected_for_order.add("Count")
         else:
             for col in params.columns:
                 if col in group_cols:
                     continue
                 select_parts.append(f"{agg_expr(col)} AS {_quote(col)}")
                 selected_for_order.add(col)
-        if params.show_hits:
+        if params.show_hits and (agg != "count" or params.graph_type == "timeseries"):
             select_parts.insert(len(group_cols), "count(*) AS Hits")
             selected_for_order.add("Hits")
     else:

--- a/tests/test_server_timeseries.py
+++ b/tests/test_server_timeseries.py
@@ -265,3 +265,22 @@ def test_reserved_word_column() -> None:
     assert rv.status_code == 200
     assert len(data["rows"]) == 2
     assert data["rows"][0][1] == "x"
+
+
+def test_count_group_by_num_no_extra_column() -> None:
+    app = server.create_app("TEST")
+    client = app.test_client()
+    payload: dict[str, Any] = {
+        "table": "extra",
+        "graph_type": "table",
+        "group_by": ["num"],
+        "aggregate": "Count",
+        "columns": [],
+        "time_column": "",
+    }
+    rv = client.post(
+        "/api/query", data=json.dumps(payload), content_type="application/json"
+    )
+    data = rv.get_json()
+    assert rv.status_code == 200
+    assert all(len(row) == 2 for row in data["rows"])


### PR DESCRIPTION
## Summary
- fix query building so grouped count tables show only the Hits column
- test count queries on the `extra` table with a numeric group

## Testing
- `ruff check scubaduck/server.py tests/test_server_timeseries.py`
- `pyright scubaduck/server.py tests/test_server_timeseries.py`
- `pytest -q -n 0`