### PR TITLE
fix(web): show series for count group in timeseries

### DIFF
--- a/scubaduck/static/js/view_settings.js
+++ b/scubaduck/static/js/view_settings.js
@@ -448,6 +448,9 @@ function updateSelectedColumns(type = graphTypeSel.value) {
         if (dc.include && !selectedColumns.includes(dc.name)) selectedColumns.push(dc.name);
       });
     }
+    if (type === 'timeseries' && agg === 'count' && !selectedColumns.includes('Count')) {
+      selectedColumns.push('Count');
+    }
   } else {
     selectedColumns = base.slice();
     derivedColumns.forEach(dc => {
@@ -692,8 +695,8 @@ function collectParams() {
     order_by: document.getElementById('order_by').value,
     order_dir: orderDir,
     limit: parseInt(document.getElementById('limit').value, 10),
-    columns: selectedColumns.filter(c =>
-      c !== 'Hits' && !derivedColumns.some(dc => dc.name === c)
+    columns: selectedColumns.filter(
+      c => c !== 'Hits' && c !== 'Count' && !derivedColumns.some(dc => dc.name === c)
     ),
     samples_columns: columnValues.samples.slice(),
     table_columns: columnValues.table.slice(),


### PR DESCRIPTION
## Summary
- ensure Count column is tracked for timeseries views
- avoid sending Count in query params
- test grouping by numeric column in timeseries

## Testing
- `ruff check`
- `pyright` *(fails: nodeenv failed, no network)*
- `pytest -q`