### PR TITLE
fix(server): drop duplicate count column

### DIFF
--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -296,8 +296,9 @@ def build_query(params: QueryParams, column_types: Dict[str, str] | None = None)
             return f"{agg}({expr})"
 
         if agg == "count":
-            select_parts.append("count(*) AS Count")
-            selected_for_order.add("Count")
+            if params.graph_type != "table":
+                select_parts.append("count(*) AS Count")
+                selected_for_order.add("Count")
         else:
             for col in params.columns:
                 if col in group_cols:

--- a/tests/test_server_errors.py
+++ b/tests/test_server_errors.py
@@ -62,7 +62,7 @@ def test_table_unknown_column_error() -> None:
     rv = client.post(
         "/api/query", data=json.dumps(payload), content_type="application/json"
     )
-    data = rv.get_json()
+    _ = rv.get_json()
     assert rv.status_code == 200
 
 

--- a/tests/test_server_timeseries.py
+++ b/tests/test_server_timeseries.py
@@ -268,6 +268,27 @@ def test_reserved_word_column() -> None:
     assert data["rows"][0][1] == "x"
 
 
+def test_table_count_group_by_extra() -> None:
+    app = server.create_app("TEST")
+    client = app.test_client()
+    payload = {
+        "table": "extra",
+        "graph_type": "table",
+        "time_column": "",
+        "group_by": ["num"],
+        "aggregate": "Count",
+        "columns": [],
+    }
+    rv = client.post(
+        "/api/query", data=json.dumps(payload), content_type="application/json"
+    )
+    data = rv.get_json()
+    assert rv.status_code == 200
+    rows = sorted(data["rows"])
+    assert rows == [[1, 1], [2, 1]]
+    assert all(len(r) == 2 for r in rows)
+
+
 def test_order_by_samples_table() -> None:
     app = server.app
     client = app.test_client()


### PR DESCRIPTION
# Prompt
Bug: With TEST db, extra table, table view, group by num, aggregate count, the headers and data in the table don't line up; there's one more column in data. The headers are correct: we should have num (group by column), hits, and nothing else (because this is count aggregate).

# Summary
- avoid creating a redundant `Count` column when using count aggregation on table view
- add regression test for grouping by `num` on the TEST dataset
- silence unused variable warning in tests

# Testing
- `ruff format scubaduck/server.py tests/test_server_timeseries.py tests/test_server_errors.py`
- `ruff check scubaduck/server.py tests/test_server_timeseries.py tests/test_server_errors.py`
- `pyright`
- `pytest -q`