### PR TITLE
fix(ui): show count series for numeric timestamps

### DIFF
--- a/scubaduck/static/js/timeseries_chart.js
+++ b/scubaduck/static/js/timeseries_chart.js
@@ -35,7 +35,13 @@ function showTimeSeries(data) {
   const start = data.start ? parseTs(data.start) : null;
   const end = data.end ? parseTs(data.end) : null;
   const startIdx = 1 + groups.length + hasHits;
-  const valueCols = selectedColumns.slice(groups.length + hasHits);
+  let valueCols = selectedColumns.slice(groups.length + hasHits);
+  if (
+    valueCols.length === 0 &&
+    document.getElementById('aggregate').value.toLowerCase() === 'count'
+  ) {
+    valueCols = ['Count'];
+  }
   const series = {};
   data.rows.forEach(r => {
     const ts = parseTs(r[0]);

--- a/tests/test_server_errors.py
+++ b/tests/test_server_errors.py
@@ -62,7 +62,7 @@ def test_table_unknown_column_error() -> None:
     rv = client.post(
         "/api/query", data=json.dumps(payload), content_type="application/json"
     )
-    data = rv.get_json()
+    _data = rv.get_json()
     assert rv.status_code == 200
 
 

--- a/tests/test_web_timeseries.py
+++ b/tests/test_web_timeseries.py
@@ -3,6 +3,25 @@ from __future__ import annotations
 from typing import Any
 
 from tests.web_utils import select_value
+from collections.abc import Iterator
+import threading
+import pytest
+from werkzeug.serving import make_server
+from scubaduck.server import create_app
+
+
+@pytest.fixture()
+def test_dataset_server_url() -> Iterator[str]:
+    app = create_app("TEST")
+    httpd = make_server("127.0.0.1", 0, app)
+    port = httpd.server_port
+    thread = threading.Thread(target=httpd.serve_forever)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        httpd.shutdown()
+        thread.join()
 
 
 def test_timeseries_default_query(page: Any, server_url: str) -> None:
@@ -376,3 +395,23 @@ def test_timeseries_group_links(page: Any, server_url: str) -> None:
     assert chips == ["user"]
     assert page.text_content("#legend .drill-links h4") == "Drill up"
     assert page.is_visible("#legend .drill-links a:text('Aggregate')")
+
+
+def test_timeseries_count_no_columns_numeric_time(
+    page: Any, test_dataset_server_url: str
+) -> None:
+    page.goto(test_dataset_server_url)
+    page.wait_for_selector("#graph_type", state="attached")
+    select_value(page, "#graph_type", "timeseries")
+    page.click("text=Columns")
+    page.click("#columns_none")
+    page.click("text=View Settings")
+    select_value(page, "#time_column", "ts")
+    select_value(page, "#time_unit", "s")
+    select_value(page, "#aggregate", "Count")
+    page.evaluate("window.lastResults = undefined")
+    page.click("text=Dive")
+    page.wait_for_function("window.lastResults !== undefined")
+    page.wait_for_selector("#chart path", state="attached")
+    series_count = page.eval_on_selector_all("#chart path", "els => els.length")
+    assert series_count == 1


### PR DESCRIPTION
# Summary
- show count column if no value columns selected
- add regression test for numeric timestamp timeseries
- fix unused variable in server error tests

# Testing
- `ruff check`
- `pyright`
- `pytest`