### PR TITLE
fix(server): json encode bytes

### DIFF
--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -711,6 +711,12 @@ def create_app(db_file: str | Path | None = None) -> Flask:
                 400,
             )
 
+        def _serialize(value: Any) -> Any:
+            if isinstance(value, bytes):
+                return repr(value)
+            return value
+
+        rows = [[_serialize(v) for v in r] for r in rows]
         result: Dict[str, Any] = {"sql": sql, "rows": rows}
         if params.start is not None:
             result["start"] = str(params.start)


### PR DESCRIPTION
## Summary
- handle `bytes` from SQL by escaping with Python repr before returning JSON
- test binary columns on SQLite

## Testing
- `ruff format scubaduck/server.py tests/test_server_db_types.py`
- `ruff check scubaduck/server.py tests/test_server_db_types.py`
- `pyright scubaduck/server.py tests/test_server_db_types.py`
- `pytest -q tests/test_server_db_types.py::test_sqlite_bytes`
- `pytest -q`