### PR TITLE
fix(frontend): prevent clipped rotated time labels

### DIFF
--- a/scubaduck/static/js/timeseries_chart.js
+++ b/scubaduck/static/js/timeseries_chart.js
@@ -412,11 +412,12 @@ function showTimeSeries(data) {
       line.setAttribute('stroke', '#888');
       axis.appendChild(line);
       const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+      const labelY = rotate ? height - 25 : height - 10;
       text.setAttribute('x', x);
-      text.setAttribute('y', height - 10);
+      text.setAttribute('y', labelY);
       text.setAttribute('text-anchor', 'middle');
       text.setAttribute('class', 'tick-label' + (rotate ? ' rotated' : ''));
-      if (rotate) text.setAttribute('transform', `rotate(-45 ${x} ${height - 10})`);
+      if (rotate) text.setAttribute('transform', `rotate(-45 ${x} ${labelY})`);
       text.textContent = fmt(new Date(t), lu);
       axis.appendChild(text);
     });

--- a/tests/test_web_timeseries.py
+++ b/tests/test_web_timeseries.py
@@ -376,3 +376,27 @@ def test_timeseries_group_links(page: Any, server_url: str) -> None:
     assert chips == ["user"]
     assert page.text_content("#legend .drill-links h4") == "Drill up"
     assert page.is_visible("#legend .drill-links a:text('Aggregate')")
+
+
+def test_timeseries_rotated_day_labels_padding(page: Any, server_url: str) -> None:
+    page.goto(server_url)
+    page.wait_for_selector("#graph_type", state="attached")
+    select_value(page, "#graph_type", "timeseries")
+    page.click("text=Columns")
+    page.check("#column_groups input[value='value']")
+    page.click("text=View Settings")
+    page.fill("#start", "2024-01-01 00:00:00")
+    page.fill("#end", "2024-01-16 00:00:00")
+    select_value(page, "#granularity", "1 day")
+    page.evaluate("window.lastResults = undefined")
+    page.click("text=Dive")
+    page.wait_for_function("window.lastResults !== undefined")
+    page.wait_for_selector("#chart text.tick-label", state="attached")
+    assert page.eval_on_selector_all(
+        "#chart text.tick-label.rotated", "els => els.length"
+    )
+    overflow = page.eval_on_selector(
+        "#chart",
+        "el => {const r=el.getBoundingClientRect(); return Array.from(el.querySelectorAll('text.tick-label')).some(t => t.getBoundingClientRect().bottom > r.bottom);}",
+    )
+    assert not overflow


### PR DESCRIPTION
## Summary
- add a regression test for rotated time labels
- pad x-axis tick labels so rotated labels stay inside the SVG

## Testing
- `ruff check`
- `pyright`
- `pytest -q`