### PR TITLE
fix(server): enforce series limit in sparse timeseries

### DIFF
--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -678,6 +678,7 @@ def create_app(db_file: str | Path | None = None) -> Flask:
                 )
 
         bucket_size: int | None = None
+        series_limit = params.limit
         if params.graph_type == "timeseries":
             bucket_size = _granularity_seconds(
                 params.granularity,
@@ -717,6 +718,24 @@ def create_app(db_file: str | Path | None = None) -> Flask:
             return value
 
         rows = [[_serialize(v) for v in r] for r in rows]
+
+        if (
+            params.graph_type == "timeseries"
+            and params.group_by
+            and series_limit is not None
+        ):
+            key_slice = slice(1, 1 + len(params.group_by))
+            kept: set[tuple[Any, ...]] = set()
+            filtered: list[list[Any]] = []
+            for row in rows:
+                key = tuple(row[key_slice])
+                if key not in kept:
+                    if len(kept) >= series_limit:
+                        continue
+                    kept.add(key)
+                filtered.append(row)
+            rows = filtered
+
         result: Dict[str, Any] = {"sql": sql, "rows": rows}
         if params.start is not None:
             result["start"] = str(params.start)

--- a/tests/test_server_timeseries.py
+++ b/tests/test_server_timeseries.py
@@ -154,6 +154,30 @@ def test_timeseries_limit_applies_to_series() -> None:
     assert all(r[1] == "alice" for r in data["rows"])
 
 
+def test_timeseries_sparse_limit_filtering() -> None:
+    app = server.app
+    client = app.test_client()
+    payload: dict[str, Any] = {
+        "table": "events",
+        "start": "2024-01-01 00:00:00",
+        "end": "2024-01-03 00:00:00",
+        "graph_type": "timeseries",
+        "limit": 2,
+        "group_by": ["user"],
+        "columns": ["value"],
+        "x_axis": "timestamp",
+        "granularity": "1 day",
+    }
+    rv = client.post(
+        "/api/query", data=json.dumps(payload), content_type="application/json"
+    )
+    data = rv.get_json()
+    assert rv.status_code == 200
+    assert len(data["rows"]) == 3
+    users = {r[1] for r in data["rows"]}
+    assert users == {"alice", "bob"}
+
+
 def test_timeseries_auto_and_fine_buckets() -> None:
     app = server.app
     client = app.test_client()


### PR DESCRIPTION
## Summary
- filter extra series server-side when time series buckets are sparse
- test sparse timeseries limit behaviour

## Testing
- `ruff format --quiet`
- `ruff check --quiet`
- `pyright`
- `pytest -q` *(fails: test_dropdown_scroll_to_selected[chromium])*