### PR TITLE
fix(server): handle lowercase samples order_by

### DIFF
--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -327,7 +327,7 @@ def build_query(params: QueryParams, column_types: Dict[str, str] | None = None)
         selected_for_order.update(params.columns)
 
     order_by = params.order_by
-    if order_by == "Samples":
+    if order_by and str(order_by).strip().lower() == "samples":
         order_by = "Hits"
     order_by = order_by if order_by in selected_for_order else None
 
@@ -531,7 +531,7 @@ def create_app(db_file: str | Path | None = None) -> Flask:
             time_column=payload.get("time_column", "timestamp"),
             time_unit=payload.get("time_unit", "s"),
         )
-        if params.order_by == "Samples":
+        if params.order_by and params.order_by.strip().lower() == "samples":
             params.order_by = "Hits"
         for f in payload.get("filters", []):
             params.filters.append(Filter(f["column"], f["op"], f.get("value")))

--- a/tests/test_server_timeseries.py
+++ b/tests/test_server_timeseries.py
@@ -357,6 +357,28 @@ def test_order_by_samples_timeseries() -> None:
     assert 'ORDER BY "Hits" DESC' in data["sql"]
 
 
+def test_order_by_samples_case_insensitive() -> None:
+    app = server.app
+    client = app.test_client()
+    payload: dict[str, Any] = {
+        "table": "events",
+        "start": "2024-01-01 00:00:00",
+        "end": "2024-01-03 00:00:00",
+        "graph_type": "table",
+        "order_by": "samples",
+        "order_dir": "DESC",
+        "limit": 10,
+        "columns": [],
+        "group_by": ["user"],
+    }
+    rv = client.post(
+        "/api/query", data=json.dumps(payload), content_type="application/json"
+    )
+    data = rv.get_json()
+    assert rv.status_code == 200
+    assert 'ORDER BY "Hits" DESC' in data["sql"]
+
+
 def test_show_hits_client_side() -> None:
     app = server.app
     client = app.test_client()


### PR DESCRIPTION
## Summary
- handle `order_by` value `samples` regardless of casing
- test ordering by `samples` in table view

## Testing
- `ruff format scubaduck/server.py tests/test_server_timeseries.py`
- `ruff check scubaduck/server.py tests/test_server_timeseries.py`
- `pyright scubaduck/server.py tests/test_server_timeseries.py`
- `pytest -q`