### PR TITLE
feat(server): support parquet databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ flask --app scubaduck.server run --debug
 ```
 
 By default the server loads `sample.csv`. Set the `SCUBADUCK_DB` environment
-variable to point at a different database file (CSV, SQLite or DuckDB) if you
+variable to point at a different database file (CSV, Parquet, SQLite or DuckDB) if you
 want to use another dataset. The special value `TEST` starts the server with a
 small in-memory SQLite dataset used by the automated tests. If the file does
 not exist, the server will raise a `FileNotFoundError` during startup.

--- a/scubaduck/server.py
+++ b/scubaduck/server.py
@@ -62,6 +62,11 @@ def _load_database(path: Path) -> duckdb.DuckDBPyConnection:
         con.execute(
             f"CREATE TABLE events AS SELECT * FROM read_csv_auto('{path.as_posix()}')"
         )
+    elif ext in {".parquet", ".parq"}:
+        con = duckdb.connect()
+        con.execute(
+            f"CREATE TABLE events AS SELECT * FROM read_parquet('{path.as_posix()}')"
+        )
     elif ext in {".db", ".sqlite"}:
         con = duckdb.connect()
         con.execute("LOAD sqlite")


### PR DESCRIPTION
## Summary
- support Parquet files in `_load_database`
- document Parquet option in README
- test SCUBADUCK_DB environment variable with a Parquet file

## Testing
- `ruff check scubaduck/server.py tests/test_server_db_types.py`
- `pyright`
- `pytest -q`